### PR TITLE
Fix Adora-only reliance buff skill

### DIFF
--- a/styles_Version12.css
+++ b/styles_Version12.css
@@ -265,6 +265,7 @@ body {
 .skillCard.green { border-left-color: #52c41a; }
 .skillCard.red { border-left-color: #ff7875; }
 .skillCard.blue { border-left: 6px solid #1890ff !important; }
+.skillCard.orange { border-left-color: #fa8c16; }
 .skillCard:hover { transform: translateY(-1px); background: #141c2b; }
 .skillCard.disabled { opacity: .6; filter: grayscale(0.1); cursor: not-allowed; }
 


### PR DESCRIPTION
## Summary
- move the "只能靠你了。。" skill from Dario's unlocks to Adora's late-game kit
- rename the helper to `adoraDepend` so the buff application matches the owning hero

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69045bf1af148332ac73a84bcd2d28be