### PR TITLE
Exaggerate attack FX and fix float positioning

### DIFF
--- a/styles_Version12.css
+++ b/styles_Version12.css
@@ -265,6 +265,7 @@ body {
 .skillCard.green { border-left-color: #52c41a; }
 .skillCard.red { border-left-color: #ff7875; }
 .skillCard.blue { border-left: 6px solid #1890ff !important; }
+.skillCard.orange { border-left-color: #fa8c16; }
 .skillCard:hover { transform: translateY(-1px); background: #141c2b; }
 .skillCard.disabled { opacity: .6; filter: grayscale(0.1); cursor: not-allowed; }
 


### PR DESCRIPTION
## Summary
- add a new slash-and-flash attack FX with heavy and true-damage variants that play for damage and GOD'S WILL
- anchor combat number, heal, and status floats to unit bounds so stacked HP/SP values stay aligned
- add heavy camera shake handling and reuse the new FX helpers when GOD'S WILL or buffs consume SP

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69045bf1af148332ac73a84bcd2d28be