### PR TITLE
Add per-skill FX and Neyla execute

### DIFF
--- a/script.js
+++ b/script.js
@@ -44,6 +44,7 @@ function aiLog(u,msg){ if(DEBUG_AI) appendLog(`[AI] ${u.name}: ${msg}`); }
 const inventory = { pistol: false };
 
 let roundsPassed = 0;
+let playerBonusStepsNextTurn = 0;
 function computeBaseSteps(){ return Math.min(BASE_START_STEPS + roundsPassed, MAX_STEPS); }
 
 let playerSteps = computeBaseSteps();
@@ -152,6 +153,8 @@ function createUnit(id, name, side, level, r, c, maxHp, maxSp, restoreOnZeroPct,
       bleed: 0,
       hazBleedTurns: 0,
       recoverStacks: 0,          // “恢复”Buff 层数（每大回合开始消耗一层，+5HP）
+      jixueStacks: 0,            // “鸡血”Buff 层数（下一次攻击伤害x2）
+      dependStacks: 0,           // “依赖”Buff 层数（下一次攻击真实伤害，结算后清空自身SP）
     },
     dmgDone: 0,
     skillPool: [],
@@ -318,29 +321,364 @@ function injectFXStyles(){
   .spbar .spfill { height: 100%; background: #40a9ff; }
 
   .fx-layer { position: absolute; inset: 0; pointer-events: none; z-index: var(--fx-z); }
-  .fx { position: absolute; will-change: transform, opacity; }
+  .fx { position: absolute; will-change: transform, opacity; --fx-offset-x: 0px; --fx-offset-y: -28px; }
   .fx-pop { animation: fx-pop 280ms ease-out forwards; }
   .fx-float { animation: fx-float-up 900ms ease-out forwards; }
   .fx-impact { width: 60px; height: 60px; background: radial-gradient(closest-side, rgba(255,255,255,0.9), rgba(255,180,0,0.5) 60%, transparent 70%); border-radius: 50%;
                animation: fx-impact 380ms ease-out forwards; mix-blend-mode: screen; }
   .fx-number { font-weight: 800; font-size: 18px; text-shadow: 0 1px 0 #000, 0 0 8px rgba(0,0,0,0.35); }
-  .fx-number.hp { color: #ff4d4f; }
-  .fx-number.sp { color: #36cfc9; }
+  .fx-number.hp.damage { color: #ff4d4f; }
+  .fx-number.hp.heal { color: #73d13d; }
+  .fx-number.sp.damage { color: #9254de; }
+  .fx-number.sp.heal { color: #40a9ff; }
+  .fx-number.status { font-size: 16px; letter-spacing: 0.4px; }
+  .fx-number.status.buff { color: #fa8c16; }
+  .fx-number.status.debuff { color: #a8071a; }
+  .fx-attack { width: 150px; height: 150px; position: absolute; transform: translate(-50%, -50%); pointer-events: none;
+               filter: drop-shadow(0 10px 24px rgba(0,0,0,0.55)); mix-blend-mode: screen;
+               --attack-scale: 1; animation: fx-attack-fade 520ms ease-out forwards; }
+  .fx-attack.heavy { --attack-scale: 1.25; animation-duration: 640ms; }
+  .fx-attack.true-damage { mix-blend-mode: lighten; }
+  .fx-attack .flash { position: absolute; left: 50%; top: 50%; width: 68%; height: 68%;
+                      background: radial-gradient(circle, rgba(255,244,214,0.95) 0%, rgba(255,161,22,0.65) 60%, rgba(255,101,9,0) 100%);
+                      border-radius: 50%; transform: translate(-50%, -50%) scale(0.45);
+                      animation: fx-attack-flash 420ms ease-out forwards; }
+  .fx-attack.true-damage .flash { background: radial-gradient(circle, rgba(245,235,255,0.95) 0%, rgba(166,93,255,0.7) 55%, rgba(116,55,255,0) 100%); }
+  .fx-attack .slash { position: absolute; left: 50%; top: 50%; width: 22px; height: 120%; border-radius: 999px;
+                      background: linear-gradient(180deg, rgba(255,255,255,0) 0%, rgba(255,255,255,0.9) 35%, rgba(255,128,17,0.9) 68%, rgba(255,255,255,0) 100%);
+                      opacity: 0; transform-origin: 50% 100%; }
+  .fx-attack.true-damage .slash { background: linear-gradient(180deg, rgba(255,255,255,0) 0%, rgba(255,255,255,0.92) 35%, rgba(145,102,255,0.94) 68%, rgba(255,255,255,0) 100%); }
+  .fx-attack .slash.main { animation: fx-attack-slash 420ms ease-out forwards; }
+  .fx-attack .slash.reverse { animation: fx-attack-slash-rev 420ms ease-out forwards; }
+  .fx-attack .ring { position: absolute; left: 50%; top: 50%; width: 56%; height: 56%; border-radius: 50%; border: 3px solid rgba(255,198,73,0.95);
+                     transform: translate(-50%, -50%) scale(0.4); opacity: 0; box-shadow: 0 0 22px rgba(255,157,46,0.45);
+                     animation: fx-attack-ring 520ms ease-out forwards; }
+  .fx-attack.true-damage .ring { border-color: rgba(155,110,255,0.95); box-shadow: 0 0 26px rgba(155,110,255,0.55); }
+  .fx-attack .spark { position: absolute; left: 50%; top: 50%; width: 14px; height: 14px; border-radius: 50%;
+                      background: radial-gradient(circle, rgba(255,255,255,0.95) 0%, rgba(255,255,255,0) 65%);
+                      opacity: 0; transform-origin: 0 0; --spark-angle: 0deg;
+                      animation: fx-attack-spark 480ms ease-out forwards; }
+  .fx-attack.true-damage .spark { background: radial-gradient(circle, rgba(255,255,255,0.95) 0%, rgba(166,93,255,0) 65%); }
+  .fx-attack .spark.left { --spark-angle: -40deg; }
+  .fx-attack .spark.right { --spark-angle: 140deg; }
+  .skill-fx { position: absolute; transform: translate(-50%, -50%); pointer-events: none; mix-blend-mode: screen; opacity: 0;
+              filter: drop-shadow(0 12px 26px rgba(0,0,0,0.55)); animation: skill-fx-fade 680ms ease-out forwards; }
+  .skill-fx .glyph { font-weight: 800; font-size: 26px; letter-spacing: 1px; color: var(--skill-outline, rgba(255,255,255,0.85));
+                     text-shadow: 0 0 12px rgba(255,255,255,0.35); }
+  .skill-fx.slash { width: 160px; height: 160px; }
+  .skill-fx.slash .flash { position: absolute; left: 50%; top: 50%; width: 62%; height: 62%; border-radius: 50%; opacity: 0;
+                            background: radial-gradient(circle, var(--skill-secondary, rgba(255,255,255,0.8)) 0%, rgba(255,255,255,0) 70%);
+                            transform: translate(-50%, -50%) scale(0.4); animation: skill-slash-flash 420ms ease-out forwards; }
+  .skill-fx.slash .ring { position: absolute; left: 50%; top: 50%; width: 56%; height: 56%; border-radius: 50%;
+                          border: 3px solid var(--skill-secondary, rgba(255,255,255,0.65)); opacity: 0;
+                          transform: translate(-50%, -50%) scale(0.35);
+                          box-shadow: 0 0 18px var(--skill-secondary, rgba(255,255,255,0.35)); animation: skill-slash-ring 520ms ease-out forwards; }
+  .skill-fx.slash .sparks { position: absolute; inset: 0; }
+  .skill-fx.slash .spark { position: absolute; left: 50%; top: 50%; width: 16px; height: 16px; border-radius: 50%; opacity: 0;
+                           background: radial-gradient(circle, rgba(255,255,255,0.95) 0%, rgba(255,255,255,0) 70%);
+                           transform-origin: 0 0; animation: skill-slash-spark 480ms ease-out forwards; }
+  .skill-fx.slash .spark.left { --spark-angle: -50deg; }
+  .skill-fx.slash .spark.right { --spark-angle: 140deg; }
+  .skill-fx.slash .strokes { position: absolute; inset: 0; }
+  .skill-fx.slash .stroke { position: absolute; left: 50%; top: 50%; width: 26px; height: 120%; border-radius: 999px; opacity: 0;
+                            transform-origin: 50% 100%; background: linear-gradient(180deg, rgba(255,255,255,0), var(--skill-primary, rgba(255,255,255,0.92)) 45%, rgba(255,255,255,0));
+                            animation: skill-slash-stroke 520ms ease-out forwards; }
+  .skill-fx.slash .stroke[data-index="0"] { --stroke-offset: -18deg; --stroke-shift: -6deg; }
+  .skill-fx.slash .stroke[data-index="1"] { --stroke-offset: 0deg; --stroke-shift: 0deg; animation-delay: 40ms; }
+  .skill-fx.slash .stroke[data-index="2"] { --stroke-offset: 20deg; --stroke-shift: 8deg; animation-delay: 70ms; }
+  .skill-fx.claw { width: 160px; height: 160px; }
+  .skill-fx.claw .burst { position: absolute; left:50%; top:50%; width: 68%; height:68%; border-radius: 50%; opacity:0.8;
+                           transform: translate(-50%,-50%) scale(0.4);
+                           background: radial-gradient(circle, var(--skill-secondary, rgba(255,255,255,0.7)) 0%, rgba(255,255,255,0) 70%);
+                           animation: skill-claw-burst 520ms ease-out forwards; }
+  .skill-fx.claw[data-variant="mecha"] .burst { box-shadow: 0 0 22px var(--skill-primary, rgba(255,255,255,0.6));
+                                                 background: radial-gradient(circle, rgba(255,255,255,0.65) 0%, var(--skill-secondary, rgba(255,255,255,0.0)) 70%); }
+  .skill-fx.claw .scratch { position:absolute; left:50%; top:50%; width:12px; height:120%; opacity:0; transform-origin:50% 0;
+                             animation: skill-claw-scratch 560ms ease-out forwards; }
+  .skill-fx.claw .scratch span { display:block; width:100%; height:100%; border-radius:999px;
+                                 background: linear-gradient(180deg, rgba(255,255,255,0.05), var(--skill-primary,#ffffff) 55%, rgba(255,255,255,0));
+                                 box-shadow: 0 0 16px var(--skill-primary, rgba(255,255,255,0.35)); }
+  .skill-fx.claw .shard { position:absolute; left:50%; top:50%; width:18px; height:38px; border-radius:999px; opacity:0;
+                          transform-origin:50% 90%; background: linear-gradient(180deg, rgba(255,255,255,0.3), var(--skill-primary, rgba(255,255,255,0.9)) 60%, rgba(255,255,255,0));
+                          filter: drop-shadow(0 0 10px rgba(255,255,255,0.45)); animation: skill-claw-shard 520ms ease-out forwards; }
+  .skill-fx.claw[data-variant="mecha"] .servo-ring { position:absolute; left:50%; top:50%; width:130%; height:130%; border-radius:50%;
+                                                       border:3px solid var(--skill-primary, rgba(255,255,255,0.85)); opacity:0;
+                                                       transform: translate(-50%, -50%) scale(0.4);
+                                                       box-shadow: 0 0 18px var(--skill-secondary, rgba(255,255,255,0.35));
+                                                       animation: skill-claw-servo 620ms ease-out forwards; }
+  .skill-fx.claw[data-variant="mecha"] .servo-flare { position:absolute; left:50%; top:50%; width:84%; height:84%; border-radius:50%; opacity:0;
+                                                        transform: translate(-50%, -50%) scale(0.5);
+                                                        background: radial-gradient(circle, rgba(255,255,255,0.7) 0%, rgba(255,255,255,0) 70%);
+                                                        animation: skill-claw-servo-flare 600ms ease-out forwards; }
+  .skill-fx.claw[data-variant="mecha"] .mecha-sparks { position:absolute; inset:0; }
+  .skill-fx.claw[data-variant="mecha"] .mecha-sparks .spark { position:absolute; left:50%; top:50%; width:18px; height:18px; border-radius:50%;
+                                                                background: radial-gradient(circle, rgba(255,255,255,0.95) 0%, rgba(255,255,255,0) 70%);
+                                                                opacity:0; transform-origin:0 0; animation: skill-claw-mecha-spark 520ms ease-out forwards; }
+  .skill-fx.claw[data-variant="mecha"] .mecha-sparks .spark.one { --spark-angle: -35deg; }
+  .skill-fx.claw[data-variant="mecha"] .mecha-sparks .spark.two { --spark-angle: 145deg; animation-delay: 70ms; }
+  .skill-fx.claw .scratch[data-index="0"] { --scratch-shift:-28px; }
+  .skill-fx.claw .scratch[data-index="1"] { --scratch-shift:-12px; animation-delay: 30ms; }
+  .skill-fx.claw .scratch[data-index="2"] { --scratch-shift: 6px; animation-delay: 60ms; }
+  .skill-fx.claw .scratch[data-index="3"] { --scratch-shift: 22px; animation-delay: 90ms; }
+  .skill-fx.claw .scratch[data-index="4"] { --scratch-shift: 38px; animation-delay: 120ms; }
+  .skill-fx.beam { width: calc(var(--skill-length, 140px) + 60px); height: 80px; }
+  .skill-fx.beam .muzzle { position:absolute; left:50%; top:50%; width:52px; height:52px; border-radius:50%; opacity:0.8;
+                           transform: translate(-50%,-50%) scale(0.35);
+                           background: radial-gradient(circle, var(--skill-secondary, rgba(255,255,255,0.85)) 0%, rgba(255,255,255,0) 70%);
+                           animation: skill-beam-muzzle 360ms ease-out forwards; }
+  .skill-fx.beam .trail { position:absolute; left:50%; top:50%; height:12px; width: var(--skill-length, 140px);
+                          background: linear-gradient(90deg, var(--skill-secondary, rgba(255,255,255,0.45)) 0%, var(--skill-primary, rgba(255,255,255,0.95)) 70%, rgba(255,255,255,0) 100%);
+                          border-radius: 999px; opacity:0; transform-origin:0 50%; animation: skill-beam-trail 360ms ease-out forwards; }
+  .skill-fx.beam .flare { position:absolute; right:8%; top:50%; width:42px; height:42px; border-radius:50%; opacity:0;
+                          background: radial-gradient(circle, rgba(255,255,255,0.85) 0%, transparent 70%);
+                          animation: skill-beam-flare 380ms ease-out forwards; }
+  .skill-fx.burst { width: 200px; height: 200px; }
+  .skill-fx.burst .ring { position:absolute; left:50%; top:50%; width:70%; height:70%; border-radius:50%; border:3px solid var(--skill-primary,#ffffff);
+                          transform:translate(-50%,-50%) scale(0.4); opacity:0; animation: skill-burst-ring 620ms ease-out forwards; }
+  .skill-fx.burst .wave { position:absolute; left:50%; top:50%; width:96%; height:96%; border-radius:50%; opacity:0;
+                          background: radial-gradient(circle, var(--skill-secondary, rgba(255,255,255,0.6)) 0%, rgba(255,255,255,0) 80%);
+                          transform:translate(-50%,-50%) scale(0.3); animation: skill-burst-wave 660ms ease-out forwards; }
+  .skill-fx.burst .core { position:absolute; left:50%; top:50%; width:38%; height:38%; border-radius:50%; opacity:0.9;
+                          transform:translate(-50%,-50%); background: radial-gradient(circle, rgba(255,255,255,0.92) 0%, var(--skill-primary, rgba(255,255,255,0.85)) 80%);
+                          animation: skill-burst-core 420ms ease-out forwards; }
+  .skill-fx.aura { width: 170px; height: 170px; filter: drop-shadow(0 0 16px var(--skill-primary, rgba(255,255,255,0.35))); }
+  .skill-fx.aura .halo { position:absolute; left:50%; top:50%; width:86%; height:86%; border-radius:50%; opacity:0;
+                          transform:translate(-50%,-50%) scale(0.6);
+                          background: radial-gradient(circle, var(--skill-secondary, rgba(255,255,255,0.75)) 0%, rgba(255,255,255,0) 75%);
+                          animation: skill-aura-halo 760ms ease-out forwards; }
+  .skill-fx.aura .glyph { position:absolute; left:50%; top:50%; transform:translate(-50%,-50%); opacity:0;
+                          animation: skill-aura-glyph 720ms ease-out forwards; }
+  .skill-fx.aura .particles { position:absolute; inset:0; background: radial-gradient(circle, var(--skill-primary, rgba(255,255,255,0.35)) 0%, rgba(255,255,255,0) 70%);
+                              border-radius:50%; opacity:0.6; filter: blur(12px); animation: skill-aura-pulse 780ms ease-out forwards; }
+  .skill-fx.lightning { width: 180px; height: 180px; }
+  .skill-fx.lightning .glow { position:absolute; left:50%; top:50%; width:80%; height:80%; border-radius:50%; opacity:0.8;
+                               transform:translate(-50%,-50%) scale(0.4); background: radial-gradient(circle, var(--skill-secondary, rgba(255,255,255,0.85)) 0%, rgba(255,255,255,0) 75%);
+                               animation: skill-lightning-glow 520ms ease-out forwards; }
+  .skill-fx.lightning .bolt { position:absolute; left:50%; top:50%; width:6px; height:110%; opacity:0;
+                              background: linear-gradient(180deg, rgba(255,255,255,0), var(--skill-primary,#ffffff) 45%, rgba(255,255,255,0));
+                              transform-origin:50% 0; animation: skill-lightning-bolt 520ms ease-out forwards; }
+  .skill-fx.lightning .bolt[data-index="0"] { transform: translate(-50%, -50%) rotate(calc(var(--skill-angle,0deg) - 18deg)); }
+  .skill-fx.lightning .bolt[data-index="1"] { transform: translate(-50%, -50%) rotate(calc(var(--skill-angle,0deg) + 6deg)); animation-delay: 50ms; }
+  .skill-fx.lightning .bolt[data-index="2"] { transform: translate(-50%, -50%) rotate(calc(var(--skill-angle,0deg) + 28deg)); animation-delay: 90ms; }
+  .skill-fx.lightning .bolt[data-index="3"] { transform: translate(-50%, -50%) rotate(calc(var(--skill-angle,0deg) - 40deg)); animation-delay: 120ms; }
+  .skill-fx.rune { width: 190px; height: 190px; }
+  .skill-fx.rune .sigil { position:absolute; left:50%; top:50%; width:74%; height:74%; border-radius:50%; border:2px solid var(--skill-primary,#ffffff);
+                          transform:translate(-50%,-50%) scale(0.4); opacity:0; animation: skill-rune-circle 700ms ease-out forwards; }
+  .skill-fx.rune .orbit { position:absolute; left:50%; top:50%; width:90%; height:90%; border-radius:50%; border:1px dashed var(--skill-secondary,#ffffff);
+                          transform:translate(-50%,-50%); opacity:0.65; animation: skill-rune-spin 900ms linear forwards; }
+  .skill-fx.rune .flare { position:absolute; left:50%; top:50%; width:44%; height:44%; border-radius:50%; opacity:0;
+                          background: radial-gradient(circle, rgba(255,255,255,0.92) 0%, var(--skill-primary, rgba(255,255,255,0.82)) 80%);
+                          transform:translate(-50%,-50%); animation: skill-rune-flare 520ms ease-out forwards; }
+  .skill-fx.impact { width: 180px; height: 180px; }
+  .skill-fx.impact .shock { position:absolute; left:50%; top:50%; width:70%; height:70%; border-radius:50%; opacity:0;
+                             background: radial-gradient(circle, var(--skill-primary, rgba(255,255,255,0.75)) 0%, rgba(255,255,255,0) 80%);
+                             transform:translate(-50%,-50%) scale(0.45); animation: skill-impact-shock 640ms ease-out forwards; }
+  .skill-fx.impact .dust { position:absolute; left:50%; top:65%; width:120%; height:40%; opacity:0.7;
+                           background: radial-gradient(circle, var(--skill-secondary, rgba(255,255,255,0.6)) 0%, rgba(255,255,255,0) 80%);
+                           transform:translate(-50%,-50%) scaleX(0.4); animation: skill-impact-dust 720ms ease-out forwards; filter: blur(6px); }
+  .skill-fx.impact .cracks { position:absolute; left:50%; top:50%; width:80%; height:80%; opacity:0;
+                             background: radial-gradient(circle, rgba(255,255,255,0.75) 0%, rgba(255,255,255,0) 75%);
+                             transform:translate(-50%,-50%) scale(0.3); mask: radial-gradient(circle, transparent 45%, #000 46%);
+                             animation: skill-impact-crack 620ms ease-out forwards; }
+  .skill-fx.cascade { width: 130px; height: 200px; }
+  .skill-fx.cascade .column { position:absolute; left:50%; top:0; width:46px; height:100%; opacity:0.75;
+                               background: linear-gradient(180deg, var(--skill-primary, rgba(255,255,255,0.7)) 0%, rgba(255,255,255,0) 85%);
+                               transform:translateX(-50%); animation: skill-cascade-column 720ms ease-out forwards; }
+  .skill-fx.cascade .drop { position:absolute; left:50%; width:14px; height:24px; border-radius:999px;
+                             background: radial-gradient(circle, rgba(255,255,255,0.9) 0%, var(--skill-secondary, rgba(255,255,255,0.65)) 70%);
+                             opacity:0; animation: skill-cascade-drop 680ms ease-out forwards; }
+  .skill-fx.cascade .drop[data-index="0"] { top:10%; animation-delay: 20ms; }
+  .skill-fx.cascade .drop[data-index="1"] { top:32%; animation-delay: 70ms; }
+  .skill-fx.cascade .drop[data-index="2"] { top:56%; animation-delay: 110ms; }
+  .skill-fx.cascade .drop[data-index="3"] { top:74%; animation-delay: 150ms; }
+  .skill-fx.cascade .drop[data-index="4"] { top:20%; animation-delay: 200ms; }
+  .skill-fx.cascade .drop[data-index="5"] { top:44%; animation-delay: 240ms; }
+  .skill-fx.spiral { width: 180px; height: 180px; }
+  .skill-fx.spiral .swirl { position:absolute; left:50%; top:50%; width:80%; height:80%; border-radius:50%; border:4px solid var(--skill-primary, rgba(255,255,255,0.7));
+                             transform:translate(-50%,-50%) scale(0.3); opacity:0; animation: skill-spiral-spin 640ms ease-out forwards; }
+  .skill-fx.spiral .swirl.two { border-color: var(--skill-secondary, rgba(255,255,255,0.7)); animation-delay: 80ms; }
+  .skill-fx.spiral .center { position:absolute; left:50%; top:50%; width:32%; height:32%; border-radius:50%; opacity:0.9;
+                              background: radial-gradient(circle, rgba(255,255,255,0.92) 0%, var(--skill-secondary, rgba(255,255,255,0.75)) 90%);
+                              transform:translate(-50%,-50%); animation: skill-spiral-center 540ms ease-out forwards; }
+  .fx-death { position: absolute; transform: translate(-50%, -50%); pointer-events: none; overflow: visible;
+              filter: drop-shadow(0 14px 28px rgba(0,0,0,0.45)); animation: fx-death-fade 900ms ease-out forwards; }
+  .fx-death .piece { position: absolute; left: 0; width: 100%; height: 50%; box-sizing: border-box; border-radius: 8px;
+                     background: rgba(255,255,255,0.14); border: 1px solid rgba(255,255,255,0.28); }
+  .fx-death.player .piece { background: rgba(91,140,255,0.18); border-color: rgba(91,140,255,0.45); }
+  .fx-death.enemy  .piece { background: rgba(255,77,79,0.18); border-color: rgba(255,77,79,0.45); }
+  .fx-death .piece.top { top: 0; border-bottom-left-radius: 4px; border-bottom-right-radius: 4px;
+                         animation: fx-death-top 900ms ease-out forwards; }
+  .fx-death .piece.bottom { bottom: 0; border-top-left-radius: 4px; border-top-right-radius: 4px;
+                            animation: fx-death-bottom 900ms ease-out forwards; }
+  .fx-death.size-2 .piece { border-radius: 12px; }
+  .fx-death .crack { position: absolute; left: 50%; top: 0; width: 3px; height: 100%;
+                     background: linear-gradient(180deg, rgba(255,255,255,0.95), rgba(255,255,255,0));
+                     transform: translateX(-50%) scaleY(0); mix-blend-mode: screen;
+                     animation: fx-death-crack 260ms ease-out forwards, fx-death-fade 900ms ease-out forwards; }
+  .fx-death .dust { position: absolute; left: 50%; top: 50%; width: 100%; height: 100%;
+                    background: radial-gradient(circle, rgba(255,255,255,0.28) 0%, rgba(255,255,255,0) 70%);
+                    transform: translate(-50%, -50%) scale(0.65); opacity: 0.85;
+                    animation: fx-death-dust 900ms ease-out forwards; pointer-events: none; }
   .fx-trail { width: 6px; height: 0; background: linear-gradient(90deg, rgba(255,255,255,0), rgba(255,255,255,0.85), rgba(255,255,255,0));
               box-shadow: 0 0 8px rgba(255,255,255,0.8); transform-origin: 0 0; animation: fx-trail 220ms linear forwards; mix-blend-mode: screen; }
   .shake { animation: cam-shake 180ms ease-in-out 1; }
+  .shake-heavy { animation: cam-shake-heavy 320ms ease-in-out 1; }
   .pulse { animation: pulse 600ms ease-out 1; }
   @keyframes fx-pop { 0%{ transform: scale(0.7); opacity: 0.0; } 55%{ transform: scale(1.1); opacity: 1; } 100%{ transform: scale(1); opacity: 1; } }
-  @keyframes fx-float-up { 0%{ transform: translate(-50%,-50%) translateY(0); opacity: 1; } 100%{ transform: translate(-50%,-50%) translateY(-36px); opacity: 0; } }
+  @keyframes fx-float-up { 0%{ transform: translate(-50%,-50%) translate(var(--fx-offset-x), var(--fx-offset-y)); opacity: 1; }
+                           100%{ transform: translate(-50%,-50%) translate(var(--fx-offset-x), calc(var(--fx-offset-y) - 36px)); opacity: 0; } }
+  @keyframes fx-attack-fade { 0% { opacity: 0; transform: translate(-50%, -50%) scale(calc(var(--attack-scale, 1) * 0.75)); }
+                               35% { opacity: 1; transform: translate(-50%, -50%) scale(calc(var(--attack-scale, 1) * 1.06)); }
+                               100% { opacity: 0; transform: translate(-50%, -50%) scale(calc(var(--attack-scale, 1) * 0.92)); } }
+  @keyframes fx-attack-flash { 0% { opacity: 0; transform: translate(-50%, -50%) scale(calc(var(--attack-scale, 1) * 0.35)); }
+                               20% { opacity: 1; transform: translate(-50%, -50%) scale(calc(var(--attack-scale, 1) * 1.05)); }
+                               100% { opacity: 0; transform: translate(-50%, -50%) scale(calc(var(--attack-scale, 1) * 0.8)); } }
+  @keyframes fx-attack-slash { 0% { opacity: 0; transform: translate(-50%, -50%) rotate(calc(var(--fx-angle, 0deg) - 26deg)) scaleY(0.1) scaleX(0.6); }
+                               35% { opacity: 1; transform: translate(-50%, -50%) rotate(calc(var(--fx-angle, 0deg) - 6deg)) scaleY(1.2) scaleX(1); }
+                               100% { opacity: 0; transform: translate(-50%, -50%) rotate(calc(var(--fx-angle, 0deg) + 14deg)) scaleY(0.4) scaleX(0.85); } }
+  @keyframes fx-attack-slash-rev { 0% { opacity: 0; transform: translate(-50%, -50%) rotate(calc(var(--fx-angle, 0deg) + 154deg)) scaleY(0.1) scaleX(0.5); }
+                                   35% { opacity: 1; transform: translate(-50%, -50%) rotate(calc(var(--fx-angle, 0deg) + 174deg)) scaleY(1.1) scaleX(0.95); }
+                                   100% { opacity: 0; transform: translate(-50%, -50%) rotate(calc(var(--fx-angle, 0deg) + 198deg)) scaleY(0.35) scaleX(0.8); } }
+  @keyframes fx-attack-ring { 0% { opacity: 0; transform: translate(-50%, -50%) scale(calc(var(--attack-scale, 1) * 0.3)); }
+                              30% { opacity: 1; transform: translate(-50%, -50%) scale(calc(var(--attack-scale, 1) * 1.05)); }
+                              100% { opacity: 0; transform: translate(-50%, -50%) scale(calc(var(--attack-scale, 1) * 1.45)); } }
+  @keyframes fx-attack-spark { 0% { opacity: 0; transform: translate(-50%, -50%) rotate(var(--spark-angle, 0deg)) translateX(0) scale(0.3); }
+                               35% { opacity: 1; }
+                               100% { opacity: 0; transform: translate(-50%, -50%) rotate(var(--spark-angle, 0deg)) translateX(86px) scale(0.65); } }
+  @keyframes skill-fx-fade { 0% { opacity: 0; transform: translate(-50%, -50%) scale(0.82); }
+                             22% { opacity: 1; }
+                             100% { opacity: 0; transform: translate(-50%, -50%) scale(1.08); } }
+  @keyframes skill-slash-flash { 0% { opacity: 0; transform: translate(-50%, -50%) scale(0.4); }
+                                 35% { opacity: 1; transform: translate(-50%, -50%) scale(1.05); }
+                                 100% { opacity: 0; transform: translate(-50%, -50%) scale(1.3); } }
+  @keyframes skill-slash-ring { 0% { opacity: 0; transform: translate(-50%, -50%) scale(0.35); }
+                                40% { opacity: 1; transform: translate(-50%, -50%) scale(1.0); }
+                                100% { opacity: 0; transform: translate(-50%, -50%) scale(1.45); } }
+  @keyframes skill-slash-spark { 0% { opacity: 0; transform: translate(-50%, -50%) rotate(var(--spark-angle, 0deg)) translateX(0) scale(0.4); }
+                                 35% { opacity: 1; }
+                                 100% { opacity: 0; transform: translate(-50%, -50%) rotate(var(--spark-angle, 0deg)) translateX(90px) scale(0.7); } }
+  @keyframes skill-slash-stroke { 0% { opacity: 0; transform: translate(-50%, -50%) rotate(calc(var(--skill-angle,0deg) + var(--stroke-offset,0deg))) scaleY(0.2) scaleX(0.6); }
+                                  35% { opacity: 1; transform: translate(-50%, -50%) rotate(calc(var(--skill-angle,0deg) + var(--stroke-offset,0deg) + var(--stroke-shift,0deg))) scaleY(1.25) scaleX(1.05); }
+                                  100% { opacity: 0; transform: translate(-50%, -50%) rotate(calc(var(--skill-angle,0deg) + var(--stroke-offset,0deg) + 22deg)) scaleY(0.35) scaleX(0.8); } }
+  @keyframes skill-claw-burst { 0% { opacity: 0.65; transform: translate(-50%, -50%) scale(0.35); }
+                                60% { opacity: 0.9; transform: translate(-50%, -50%) scale(1.05); }
+                                100% { opacity: 0; transform: translate(-50%, -50%) scale(1.4); } }
+  @keyframes skill-claw-scratch { 0% { opacity: 0; transform: translate(calc(-50% + var(--scratch-shift,0px)), -60%) scaleY(0.3); }
+                                   40% { opacity: 1; transform: translate(calc(-50% + var(--scratch-shift,0px)), 10%) scaleY(1.05); }
+                                   100% { opacity: 0; transform: translate(calc(-50% + var(--scratch-shift,0px)), 60%) scaleY(0.4); } }
+  @keyframes skill-claw-shard { 0% { opacity: 0; transform: translate(calc(-50% + var(--shard-drift,0px)), -30%) rotate(calc(var(--shard-rotate,0deg) - 24deg)) scale(0.45); }
+                                 45% { opacity: 1; transform: translate(calc(-50% + var(--shard-drift,0px)), 18%) rotate(calc(var(--shard-rotate,0deg))) scale(1.05); }
+                                 100% { opacity: 0; transform: translate(calc(-50% + var(--shard-drift,0px)), 70%) rotate(calc(var(--shard-rotate,0deg) + 14deg)) scale(0.6); } }
+  @keyframes skill-claw-servo { 0% { opacity: 0; transform: translate(-50%, -50%) scale(0.35) rotate(0deg); }
+                                 35% { opacity: 1; transform: translate(-50%, -50%) scale(1.0) rotate(40deg); }
+                                 100% { opacity: 0; transform: translate(-50%, -50%) scale(1.25) rotate(90deg); } }
+  @keyframes skill-claw-servo-flare { 0% { opacity: 0; transform: translate(-50%, -50%) scale(0.6); }
+                                       40% { opacity: 0.85; transform: translate(-50%, -50%) scale(1.0); }
+                                       100% { opacity: 0; transform: translate(-50%, -50%) scale(1.35); } }
+  @keyframes skill-claw-mecha-spark { 0% { opacity: 0; transform: translate(-50%, -50%) rotate(var(--spark-angle, 0deg)) translateX(0) scale(0.4); }
+                                      40% { opacity: 1; }
+                                      100% { opacity: 0; transform: translate(-50%, -50%) rotate(var(--spark-angle, 0deg)) translateX(92px) scale(0.7); } }
+  @keyframes skill-beam-muzzle { 0% { opacity: 0; transform: translate(-50%, -50%) scale(0.25); }
+                                 45% { opacity: 1; transform: translate(-50%, -50%) scale(1.0); }
+                                 100% { opacity: 0; transform: translate(-50%, -50%) scale(1.25); } }
+  @keyframes skill-beam-trail { 0% { opacity: 0; width: 0; }
+                                30% { opacity: 1; width: var(--skill-length, 140px); }
+                                100% { opacity: 0; width: var(--skill-length, 140px); } }
+  @keyframes skill-beam-flare { 0% { opacity: 0; transform: translateY(-50%) scale(0.4); }
+                                40% { opacity: 0.9; transform: translateY(-50%) scale(1.05); }
+                                100% { opacity: 0; transform: translateY(-50%) scale(1.4); } }
+  @keyframes skill-burst-ring { 0% { opacity: 0; transform: translate(-50%, -50%) scale(0.3); }
+                                40% { opacity: 1; transform: translate(-50%, -50%) scale(1.0); }
+                                100% { opacity: 0; transform: translate(-50%, -50%) scale(1.6); } }
+  @keyframes skill-burst-wave { 0% { opacity: 0; transform: translate(-50%, -50%) scale(0.25); }
+                                45% { opacity: 0.6; transform: translate(-50%, -50%) scale(1.05); }
+                                100% { opacity: 0; transform: translate(-50%, -50%) scale(1.5); } }
+  @keyframes skill-burst-core { 0% { opacity: 0.2; transform: translate(-50%, -50%) scale(0.8); }
+                                40% { opacity: 1; transform: translate(-50%, -50%) scale(1.05); }
+                                100% { opacity: 0; transform: translate(-50%, -50%) scale(1.2); } }
+  @keyframes skill-aura-halo { 0% { opacity: 0; transform: translate(-50%, -50%) scale(0.5); }
+                                35% { opacity: 1; transform: translate(-50%, -50%) scale(1.0); }
+                                100% { opacity: 0; transform: translate(-50%, -50%) scale(1.35); } }
+  @keyframes skill-aura-glyph { 0% { opacity: 0; transform: translate(-50%, -50%) scale(0.6); }
+                                 35% { opacity: 1; transform: translate(-50%, -50%) scale(1.0); }
+                                 100% { opacity: 0; transform: translate(-50%, -50%) scale(1.12); } }
+  @keyframes skill-aura-pulse { 0% { opacity: 0.6; transform: scale(0.75); }
+                                 60% { opacity: 0.8; transform: scale(1.0); }
+                                 100% { opacity: 0; transform: scale(1.35); } }
+  @keyframes skill-lightning-glow { 0% { opacity: 0; transform: translate(-50%, -50%) scale(0.35); }
+                                    35% { opacity: 1; transform: translate(-50%, -50%) scale(1.05); }
+                                    100% { opacity: 0; transform: translate(-50%, -50%) scale(1.4); } }
+  @keyframes skill-lightning-bolt { 0% { opacity: 0; transform: translate(-50%, -50%) rotate(calc(var(--skill-angle,0deg) - 12deg)) scaleY(0.2); }
+                                   30% { opacity: 1; transform: translate(-50%, -50%) rotate(calc(var(--skill-angle,0deg) - 2deg)) scaleY(1.0); }
+                                   100% { opacity: 0; transform: translate(-50%, -50%) rotate(calc(var(--skill-angle,0deg) + 12deg)) scaleY(0.4); } }
+  @keyframes skill-rune-circle { 0% { opacity: 0; transform: translate(-50%, -50%) scale(0.4); }
+                                 35% { opacity: 1; transform: translate(-50%, -50%) scale(1.0); }
+                                 100% { opacity: 0; transform: translate(-50%, -50%) scale(1.2); } }
+  @keyframes skill-rune-spin { 0% { opacity: 0.6; transform: translate(-50%, -50%) rotate(0deg) scale(0.95); }
+                               100% { opacity: 0; transform: translate(-50%, -50%) rotate(220deg) scale(1.05); } }
+  @keyframes skill-rune-flare { 0% { opacity: 0; transform: translate(-50%, -50%) scale(0.6); }
+                                40% { opacity: 1; transform: translate(-50%, -50%) scale(1.0); }
+                                100% { opacity: 0; transform: translate(-50%, -50%) scale(1.2); } }
+  @keyframes skill-impact-shock { 0% { opacity: 0; transform: translate(-50%, -50%) scale(0.4); }
+                                  40% { opacity: 1; transform: translate(-50%, -50%) scale(1.05); }
+                                  100% { opacity: 0; transform: translate(-50%, -50%) scale(1.45); } }
+  @keyframes skill-impact-dust { 0% { opacity: 0; transform: translate(-50%, -50%) scaleX(0.4); }
+                                 40% { opacity: 0.75; transform: translate(-50%, -50%) scaleX(1.0); }
+                                 100% { opacity: 0; transform: translate(-50%, -64%) scaleX(1.3); } }
+  @keyframes skill-impact-crack { 0% { opacity: 0; transform: translate(-50%, -50%) scale(0.3); }
+                                  30% { opacity: 0.9; transform: translate(-50%, -50%) scale(0.9); }
+                                  100% { opacity: 0; transform: translate(-50%, -50%) scale(1.2); } }
+  @keyframes skill-cascade-column { 0% { opacity: 0; height: 0; }
+                                    30% { opacity: 0.75; height: 100%; }
+                                    100% { opacity: 0; height: 100%; } }
+  @keyframes skill-cascade-drop { 0% { opacity: 0; transform: translate(-50%, -30%) scale(0.6); }
+                                   40% { opacity: 1; transform: translate(-50%, 20%) scale(1.0); }
+                                   100% { opacity: 0; transform: translate(-50%, 80%) scale(0.4); } }
+  @keyframes skill-spiral-spin { 0% { opacity: 0; transform: translate(-50%, -50%) scale(0.3) rotate(0deg); }
+                                 40% { opacity: 1; transform: translate(-50%, -50%) scale(1.0) rotate(160deg); }
+                                 100% { opacity: 0; transform: translate(-50%, -50%) scale(1.2) rotate(320deg); } }
+  @keyframes skill-spiral-center { 0% { opacity: 0; transform: translate(-50%, -50%) scale(0.7); }
+                                   40% { opacity: 1; transform: translate(-50%, -50%) scale(1.05); }
+                                   100% { opacity: 0; transform: translate(-50%, -50%) scale(1.25); } }
   @keyframes fx-impact { 0%{ transform: translate(-50%,-50%) scale(0.6); opacity: 0; }
                          50%{ transform: translate(-50%,-50%) scale(1.1); opacity: 1; }
                          100%{ transform: translate(-50%,-50%) scale(0.8); opacity: 0; } }
   @keyframes fx-trail { 0% { opacity: 0; } 30% { opacity: 1; } 100% { opacity: 0; } }
+  @keyframes fx-death-top {
+    0% { transform: translate(0, 0) rotate(0deg); opacity: 1; }
+    45% { transform: translate(-5%, -12%) rotate(-4deg); opacity: 1; }
+    100% { transform: translate(-12%, -46%) rotate(-10deg); opacity: 0; }
+  }
+  @keyframes fx-death-bottom {
+    0% { transform: translate(0, 0) rotate(0deg); opacity: 1; }
+    45% { transform: translate(5%, 12%) rotate(4deg); opacity: 1; }
+    100% { transform: translate(12%, 46%) rotate(10deg); opacity: 0; }
+  }
+  @keyframes fx-death-crack {
+    0% { transform: translateX(-50%) scaleY(0); opacity: 0; }
+    60% { transform: translateX(-50%) scaleY(1); opacity: 1; }
+    100% { transform: translateX(-50%) scaleY(1); opacity: 0; }
+  }
+  @keyframes fx-death-dust {
+    0% { transform: translate(-50%, -50%) scale(0.65); opacity: 0.85; }
+    100% { transform: translate(-50%, -60%) scale(1.12); opacity: 0; }
+  }
+  @keyframes fx-death-fade {
+    0% { opacity: 1; }
+    100% { opacity: 0; }
+  }
   @keyframes cam-shake {
     0% { transform: translate(2px, -2px) scale(1.02); }
     25% { transform: translate(-2px, 2px) scale(1.02); }
     50% { transform: translate(2px, 2px) scale(1.02); }
     75% { transform: translate(-2px, -2px) scale(1.02); }
+    100% { transform: translate(0, 0) scale(1); }
+  }
+  @keyframes cam-shake-heavy {
+    0% { transform: translate(4px, -4px) scale(1.05); }
+    20% { transform: translate(-5px, 5px) scale(1.06); }
+    45% { transform: translate(5px, 4px) scale(1.05); }
+    70% { transform: translate(-4px, -5px) scale(1.04); }
     100% { transform: translate(0, 0) scale(1); }
   }
   @keyframes pulse {
@@ -358,6 +696,7 @@ function injectFXStyles(){
   .skillCard.green { border-left-color:#73d13d; }
   .skillCard.red   { border-left-color:#ff4d4f; }
   .skillCard.blue  { border-left-color:#40a9ff; }
+  .skillCard.orange{ border-left-color:#fa8c16; }
   .skillCard.pink  { border-left-color:#eb2f96; }
   .skillCard.white { border-left-color:#d9d9d9; }
   .skillCard.disabled { opacity: 0.55; cursor: not-allowed; }
@@ -408,7 +747,17 @@ function injectFXStyles(){
   `;
   const style = document.createElement('style'); style.id='fx-styles'; style.textContent=css; document.head.appendChild(style);
 }
-function ensureFxLayer(){ if(!fxLayer){ fxLayer=document.createElement('div'); fxLayer.className='fx-layer'; battleAreaEl.appendChild(fxLayer); } }
+function ensureFxLayer(){
+  if(!battleAreaEl) return null;
+  if(!fxLayer){
+    fxLayer=document.createElement('div');
+    fxLayer.className='fx-layer';
+  }
+  if(fxLayer.parentElement!==battleAreaEl){
+    battleAreaEl.appendChild(fxLayer);
+  }
+  return fxLayer;
+}
 function getCellEl(r,c){ return document.querySelector(`.cell[data-r="${r}"][data-c="${c}"]`); }
 function getCellCenter(r,c){
   const cell = getCellEl(r,c); const area = battleAreaEl;
@@ -419,16 +768,444 @@ function getCellCenter(r,c){
 function makeEl(cls, html=''){ const el=document.createElement('div'); el.className=`fx ${cls}`; if(html) el.innerHTML=html; return el; }
 function onAnimEndRemove(el, timeout=1200){ const done=()=>el.remove(); el.addEventListener('animationend',done,{once:true}); setTimeout(done, timeout); }
 function fxAtCell(r,c,el){ ensureFxLayer(); const p=getCellCenter(r,c); el.style.left=`${p.x}px`; el.style.top=`${p.y}px`; fxLayer.appendChild(el); return el; }
-function showHitFX(r,c){ const el=makeEl('fx-impact fx-pop'); fxAtCell(r,c, el); onAnimEndRemove(el,500); }
-function showDamageFloat(r,c,hp,sp){
-  ensureFxLayer();
-  if(hp>0){ const el=makeEl('fx-number hp fx-float', `-${hp}`); el.style.transform='translate(-50%,-50%)'; fxAtCell(r,c,el); onAnimEndRemove(el,900); }
-  if(sp>0){ const el=makeEl('fx-number sp fx-float', `-${sp} SP`); el.style.transform='translate(-50%,-50%)'; const p=getCellCenter(r,c); el.style.left=`${p.x+16}px`; el.style.top=`${p.y-6}px`; fxLayer.appendChild(el); onAnimEndRemove(el,900); }
+function fxAtPoint(x,y,el){ ensureFxLayer(); el.style.left=`${x}px`; el.style.top=`${y}px`; fxLayer.appendChild(el); return el; }
+function getUnitBounds(u){
+  if(!u) return null;
+  const size = Math.max(1, u.size || 1);
+  const tl = getCellEl(u.r, u.c);
+  const br = getCellEl(u.r + size - 1, u.c + size - 1);
+  if(!tl || !br) return null;
+  const left = tl.offsetLeft;
+  const top = tl.offsetTop;
+  const right = br.offsetLeft + br.offsetWidth;
+  const bottom = br.offsetTop + br.offsetHeight;
+  const width = Math.max(0, right - left);
+  const height = Math.max(0, bottom - top);
+  const centerX = left + width / 2;
+  const centerY = top + height / 2;
+  return { left, top, width, height, centerX, centerY };
 }
-function showGainFloat(r,c,hp,sp){
+function getUnitCenterPoint(u){
+  if(!u) return null;
+  const bounds = getUnitBounds(u);
+  if(bounds) return { x: bounds.centerX, y: bounds.centerY };
+  if(typeof u.r === 'number' && typeof u.c === 'number') return getCellCenter(u.r, u.c);
+  return null;
+}
+function fxAtUnit(u, el){
   ensureFxLayer();
-  if(hp>0){ const el=makeEl('fx-number hp fx-float', `+${hp}`); el.style.color='#73d13d'; el.style.transform='translate(-50%,-50%)'; fxAtCell(r,c,el); onAnimEndRemove(el,900); }
-  if(sp>0){ const el=makeEl('fx-number sp fx-float', `+${sp} SP`); el.style.color='#40a9ff'; el.style.transform='translate(-50%,-50%)'; const p=getCellCenter(r,c); el.style.left=`${p.x+16}px`; el.style.top=`${p.y-6}px`; fxLayer.appendChild(el); onAnimEndRemove(el,900); }
+  const bounds = getUnitBounds(u);
+  if(!bounds){
+    if(u) return fxAtCell(u.r, u.c, el);
+    return null;
+  }
+  el.style.left = `${bounds.centerX}px`;
+  el.style.top = `${bounds.centerY}px`;
+  el.style.width = `${bounds.width}px`;
+  el.style.height = `${bounds.height}px`;
+  el.style.transform = 'translate(-50%, -50%)';
+  fxLayer.appendChild(el);
+  return el;
+}
+function resolveFxAnchor(target){
+  if(!target) return null;
+  if(typeof target === 'string'){ const unit = units && units[target]; if(unit) return resolveFxAnchor(unit); }
+  if(target.id && typeof target.r === 'number' && typeof target.c === 'number'){
+    const bounds = getUnitBounds(target);
+    if(bounds){
+      const topOffset = Math.min(bounds.height * 0.28, 30);
+      return { x: bounds.centerX, y: bounds.top + topOffset, unit: target };
+    }
+    return resolveFxAnchor({r: target.r, c: target.c});
+  }
+  if(target.unit){ return resolveFxAnchor(target.unit); }
+  if(Array.isArray(target) && target.length>=2){ return resolveFxAnchor({r: target[0], c: target[1]}); }
+  if(typeof target.x === 'number' && typeof target.y === 'number'){ return { x: target.x, y: target.y }; }
+  if(typeof target === 'object' && typeof target.r === 'number' && typeof target.c === 'number'){
+    const pt = getCellCenter(target.r, target.c);
+    return { x: pt.x, y: pt.y, r: target.r, c: target.c };
+  }
+  return null;
+}
+function showAttackFx({attacker=null, target=null, cell=null, point=null, trueDamage=false, heavy=false}={}){
+  let anchor = null;
+  if(target){
+    if(target.id){ anchor = getUnitCenterPoint(target); }
+    else { anchor = resolveFxAnchor(target); }
+  }
+  if(!anchor && cell){ anchor = resolveFxAnchor(cell); }
+  if(!anchor && point){ anchor = resolveFxAnchor(point); }
+  if(!anchor) return null;
+  const node = makeEl('fx-attack');
+  if(trueDamage) node.classList.add('true-damage');
+  if(heavy) node.classList.add('heavy');
+  node.innerHTML = `
+    <div class="flash"></div>
+    <div class="slash main"></div>
+    <div class="slash reverse"></div>
+    <div class="ring"></div>
+    <div class="spark left"></div>
+    <div class="spark right"></div>
+  `;
+  fxAtPoint(anchor.x, anchor.y, node);
+  let angle = 0;
+  if(attacker){
+    const origin = getUnitCenterPoint(attacker);
+    if(origin){ angle = Math.atan2(anchor.y - origin.y, anchor.x - origin.x) * 180 / Math.PI; }
+  }
+  if(point && typeof point.angle === 'number'){ angle = point.angle; }
+  node.style.setProperty('--fx-angle', `${angle}deg`);
+  const leftSpark = node.querySelector('.spark.left');
+  if(leftSpark) leftSpark.style.setProperty('--spark-angle', `${angle - 65}deg`);
+  const rightSpark = node.querySelector('.spark.right');
+  if(rightSpark) rightSpark.style.setProperty('--spark-angle', `${angle + 115}deg`);
+  onAnimEndRemove(node, heavy ? 700 : 560);
+  return node;
+}
+function showHitFX(r,c, opts={}){ return showAttackFx({cell:{r,c}, ...opts}); }
+function resolveSkillFxAnchor({target=null, cell=null, point=null}){
+  let anchor = null;
+  if(target){
+    if(target.id){ anchor = getUnitCenterPoint(target); }
+    else { anchor = resolveFxAnchor(target); }
+  }
+  if(!anchor && cell){ anchor = resolveFxAnchor(cell); }
+  if(!anchor && point){ anchor = resolveFxAnchor(point); }
+  return anchor;
+}
+function computeSkillFxAngle(anchor, attacker, fallbackAngle=null){
+  if(fallbackAngle!==null){ return fallbackAngle; }
+  if(attacker){
+    const origin = getUnitCenterPoint(attacker);
+    if(origin){ return Math.atan2(anchor.y - origin.y, anchor.x - origin.x) * 180 / Math.PI; }
+  }
+  return 0;
+}
+function makeSkillFxNode(baseClass, html=''){ const node = makeEl(`skill-fx ${baseClass}`.trim(), html); return node; }
+function attachSkillFx(node, anchor){ if(!anchor) return null; fxAtPoint(anchor.x, anchor.y, node); return node; }
+function buildSlashSkillFx({anchor, angle, config}){
+  const node = makeSkillFxNode('slash');
+  node.style.setProperty('--skill-primary', config.primary || '#fff');
+  node.style.setProperty('--skill-secondary', config.secondary || 'rgba(255,255,255,0.65)');
+  node.style.setProperty('--skill-spark', config.spark || 'rgba(255,255,255,0.9)');
+  node.dataset.variant = config.variant || 'default';
+  const slashCount = Math.max(1, config.slashes || 2);
+  let slashes = '';
+  for(let i=0;i<slashCount;i++){ slashes += `<div class="stroke" data-index="${i}"></div>`; }
+  node.innerHTML = `
+    <div class="flash"></div>
+    <div class="ring"></div>
+    <div class="sparks">
+      <div class="spark left"></div>
+      <div class="spark right"></div>
+    </div>
+    <div class="strokes">${slashes}</div>
+  `;
+  node.style.setProperty('--skill-angle', `${angle}deg`);
+  onAnimEndRemove(node, config.duration || 600);
+  return attachSkillFx(node, anchor);
+}
+function buildClawSkillFx({anchor, angle, config}){
+  const node = makeSkillFxNode('claw');
+  node.style.setProperty('--skill-primary', config.primary || '#f0d088');
+  node.style.setProperty('--skill-secondary', config.secondary || '#ffefa9');
+  node.dataset.variant = config.variant || 'default';
+  const scratchCount = Math.max(3, config.scratches || 3);
+  const scratchSpacing = config.spacing ?? 16;
+  const scratchDelay = config.delayStep ?? 30;
+  const scratchBaseDelay = config.delayBase ?? 0;
+  let scratchHtml='';
+  for(let i=0;i<scratchCount;i++){
+    scratchHtml += `<div class="scratch" data-index="${i}"><span></span></div>`;
+  }
+  const shardCount = Math.max(0, config.shards|0);
+  let shardHtml='';
+  for(let i=0;i<shardCount;i++){
+    shardHtml += `<div class="shard" data-index="${i}"></div>`;
+  }
+  const mechaExtras = config.variant==='mecha'
+    ? `<div class="servo-ring"></div><div class="servo-flare"></div><div class="mecha-sparks"><span class="spark one"></span><span class="spark two"></span></div>`
+    : '';
+  node.innerHTML = `<div class="burst"></div>${mechaExtras}${shardHtml}${scratchHtml}`;
+  node.style.setProperty('--skill-angle', `${angle}deg`);
+  const scratchEls = node.querySelectorAll('.scratch');
+  const scratchPivot = (scratchCount - 1) / 2;
+  scratchEls.forEach((el,i)=>{
+    const offset = (i - scratchPivot) * scratchSpacing;
+    el.style.setProperty('--scratch-shift', `${offset}px`);
+    const delay = scratchBaseDelay + i * scratchDelay;
+    if(delay){ el.style.animationDelay = `${delay}ms`; }
+  });
+  const shardEls = node.querySelectorAll('.shard');
+  const shardPivot = shardCount > 0 ? (shardCount - 1) / 2 : 0;
+  const shardSpread = config.shardSpread ?? 22;
+  const shardArc = config.shardArc ?? 18;
+  const shardStart = config.shardStartAngle ?? -26;
+  shardEls.forEach((el,i)=>{
+    const drift = (i - shardPivot) * shardSpread;
+    const rot = shardStart + (i - shardPivot) * shardArc;
+    el.style.setProperty('--shard-drift', `${drift}px`);
+    el.style.setProperty('--shard-rotate', `${rot}deg`);
+    el.style.animationDelay = `${90 + i * 45}ms`;
+  });
+  onAnimEndRemove(node, config.duration || 640);
+  return attachSkillFx(node, anchor);
+}
+function buildBeamSkillFx({anchor, angle, config}){
+  const node = makeSkillFxNode('beam');
+  node.style.setProperty('--skill-primary', config.primary || '#ffd77f');
+  node.style.setProperty('--skill-secondary', config.secondary || '#fff2c2');
+  node.style.setProperty('--skill-glow', config.glow || 'rgba(255,255,255,0.8)');
+  node.dataset.variant = config.variant || 'default';
+  node.innerHTML = `
+    <div class="muzzle"></div>
+    <div class="trail"></div>
+    <div class="flare"></div>
+  `;
+  node.style.setProperty('--skill-angle', `${angle}deg`);
+  node.style.setProperty('--skill-length', `${config.length || 120}px`);
+  onAnimEndRemove(node, config.duration || 420);
+  return attachSkillFx(node, anchor);
+}
+function buildBurstSkillFx({anchor, angle, config}){
+  const node = makeSkillFxNode('burst');
+  node.style.setProperty('--skill-primary', config.primary || '#8fd3ff');
+  node.style.setProperty('--skill-secondary', config.secondary || '#dff4ff');
+  node.style.setProperty('--skill-spark', config.spark || '#ffffff');
+  node.dataset.variant = config.variant || 'default';
+  node.innerHTML = `
+    <div class="ring"></div>
+    <div class="wave"></div>
+    <div class="core"></div>
+  `;
+  onAnimEndRemove(node, config.duration || 680);
+  return attachSkillFx(node, anchor);
+}
+function buildAuraSkillFx({anchor, angle, config}){
+  const node = makeSkillFxNode('aura');
+  node.style.setProperty('--skill-primary', config.primary || '#ffb86c');
+  node.style.setProperty('--skill-secondary', config.secondary || '#ffe9c7');
+  node.style.setProperty('--skill-outline', config.outline || 'rgba(255,255,255,0.75)');
+  node.dataset.variant = config.variant || 'default';
+  node.innerHTML = `
+    <div class="halo"></div>
+    <div class="glyph">${config.glyph || ''}</div>
+    <div class="particles"></div>
+  `;
+  onAnimEndRemove(node, config.duration || 900);
+  return attachSkillFx(node, anchor);
+}
+function buildLightningSkillFx({anchor, angle, config}){
+  const node = makeSkillFxNode('lightning');
+  node.style.setProperty('--skill-primary', config.primary || '#ff9cff');
+  node.style.setProperty('--skill-secondary', config.secondary || '#ffe6ff');
+  const bolts = Math.max(2, config.bolts || 3);
+  let html='';
+  for(let i=0;i<bolts;i++){
+    html += `<div class="bolt" data-index="${i}"></div>`;
+  }
+  node.innerHTML = `<div class="glow"></div>${html}`;
+  node.style.setProperty('--skill-angle', `${angle}deg`);
+  onAnimEndRemove(node, config.duration || 560);
+  return attachSkillFx(node, anchor);
+}
+function buildRuneSkillFx({anchor, angle, config}){
+  const node = makeSkillFxNode('rune');
+  node.style.setProperty('--skill-primary', config.primary || '#b37bff');
+  node.style.setProperty('--skill-secondary', config.secondary || '#f0ddff');
+  node.dataset.variant = config.variant || 'default';
+  node.innerHTML = `
+    <div class="sigil"></div>
+    <div class="orbit"></div>
+    <div class="flare"></div>
+  `;
+  onAnimEndRemove(node, config.duration || 740);
+  return attachSkillFx(node, anchor);
+}
+function buildImpactSkillFx({anchor, angle, config}){
+  const node = makeSkillFxNode('impact');
+  node.style.setProperty('--skill-primary', config.primary || '#ff6f6f');
+  node.style.setProperty('--skill-secondary', config.secondary || '#ffd3d3');
+  node.innerHTML = `
+    <div class="shock"></div>
+    <div class="dust"></div>
+    <div class="cracks"></div>
+  `;
+  onAnimEndRemove(node, config.duration || 780);
+  return attachSkillFx(node, anchor);
+}
+function buildCascadeSkillFx({anchor, angle, config}){
+  const node = makeSkillFxNode('cascade');
+  node.style.setProperty('--skill-primary', config.primary || '#72e7ff');
+  node.style.setProperty('--skill-secondary', config.secondary || '#c6f7ff');
+  const droplets = Math.max(3, config.droplets || 4);
+  let html='';
+  for(let i=0;i<droplets;i++){
+    html += `<div class="drop" data-index="${i}"></div>`;
+  }
+  node.innerHTML = `<div class="column"></div>${html}`;
+  onAnimEndRemove(node, config.duration || 800);
+  return attachSkillFx(node, anchor);
+}
+function buildSpiralSkillFx({anchor, angle, config}){
+  const node = makeSkillFxNode('spiral');
+  node.style.setProperty('--skill-primary', config.primary || '#f5f56b');
+  node.style.setProperty('--skill-secondary', config.secondary || '#fff9c4');
+  node.innerHTML = `
+    <div class="swirl one"></div>
+    <div class="swirl two"></div>
+    <div class="center"></div>
+  `;
+  onAnimEndRemove(node, config.duration || 760);
+  return attachSkillFx(node, anchor);
+}
+const SKILL_FX_BUILDERS = {
+  slash: buildSlashSkillFx,
+  claw: buildClawSkillFx,
+  beam: buildBeamSkillFx,
+  burst: buildBurstSkillFx,
+  aura: buildAuraSkillFx,
+  lightning: buildLightningSkillFx,
+  rune: buildRuneSkillFx,
+  impact: buildImpactSkillFx,
+  cascade: buildCascadeSkillFx,
+  spiral: buildSpiralSkillFx,
+};
+const SKILL_FX_CONFIG = {
+  'adora:短匕轻挥':        {type:'slash', primary:'#ff82b6', secondary:'rgba(255,158,206,0.55)', spark:'#ffe5f5', slashes:2},
+  'adora:呀！你不要靠近我呀！！': {type:'spiral', primary:'#ff9f6a', secondary:'#ffe0c1'},
+  'adora:自制粉色迷你电击装置': {type:'lightning', primary:'#ff87ff', secondary:'#ffd7ff', bolts:4},
+  'adora:略懂的医术！':     {type:'aura', primary:'#75e6a7', secondary:'#c6ffde', outline:'rgba(255,255,255,0.85)', glyph:'✚'},
+  'adora:加油哇！':         {type:'aura', primary:'#ffcf74', secondary:'#ffe9bb', glyph:'★'},
+  'adora:只能靠你了。。':   {type:'impact', primary:'#ff6161', secondary:'#ffd6d6'},
+  'adora:枪击':             {type:'beam', primary:'#ffd780', secondary:'#fff1c2', glow:'rgba(255,255,255,0.9)', variant:'adora'},
+  'dario:机械爪击':         {type:'claw', primary:'#f6c55b', secondary:'#fff3c7', scratches:6, spacing:18, delayStep:26, shards:6, shardSpread:18, shardArc:16, shardStartAngle:-34, variant:'mecha'},
+  'dario:枪击':             {type:'beam', primary:'#9ee0ff', secondary:'#dcf6ff', glow:'rgba(255,255,255,0.85)', variant:'dario'},
+  'dario:迅捷步伐':         {type:'spiral', primary:'#7fe8ff', secondary:'#d6f8ff'},
+  'dario:拿来吧你！':       {type:'claw', primary:'#ffa56a', secondary:'#ffd7b9', scratches:5},
+  'dario:先苦后甜':         {type:'aura', primary:'#c9a4ff', secondary:'#eedcff', glyph:'↻'},
+  'karma:沙包大的拳头':     {type:'slash', primary:'#ff9059', secondary:'rgba(255,192,160,0.7)', spark:'#fff0e4', slashes:1},
+  'karma:枪击':             {type:'beam', primary:'#f38fff', secondary:'#ffd9ff', glow:'rgba(255,255,255,0.85)', variant:'karma'},
+  'karma:都听你的':         {type:'spiral', primary:'#ffdd77', secondary:'#fff1bd'},
+  'karma:嗜血之握':         {type:'claw', primary:'#d95ffb', secondary:'#f0b8ff', scratches:3},
+  'karma:深呼吸':           {type:'aura', primary:'#7ecfff', secondary:'#d7f1ff', glyph:'息'},
+  'haz:鱼叉穿刺':           {type:'beam', primary:'#5fd9ff', secondary:'#c5f2ff', glow:'rgba(255,255,255,0.8)', variant:'harpoon'},
+  'haz:深海猎杀':           {type:'slash', primary:'#4ecdf2', secondary:'rgba(170,236,255,0.6)', spark:'#e3fbff', slashes:3},
+  'haz:猎神之叉':           {type:'slash', primary:'#ffe373', secondary:'rgba(255,233,152,0.7)', spark:'#fff6c4', slashes:2},
+  'haz:锁链缠绕':           {type:'rune', primary:'#8ed8ff', secondary:'#dff3ff', variant:'chain'},
+  'haz:鲸落':               {type:'cascade', primary:'#8ae8ff', secondary:'#d5f9ff', droplets:6},
+  'haz:怨念滋生':           {type:'rune', primary:'#b56fff', secondary:'#eed4ff', variant:'curse'},
+  'haz:付出代价':           {type:'slash', primary:'#ff6d6d', secondary:'rgba(255,158,158,0.7)', spark:'#ffd3d3', slashes:4},
+  'haz:仇恨之叉':           {type:'slash', primary:'#ffa365', secondary:'rgba(255,202,153,0.7)', spark:'#ffe7d4', slashes:4},
+  'haz:怨念滋生·恐惧':      {type:'rune', primary:'#9c60ff', secondary:'#e4ceff', variant:'fear'},
+  'haz:锁链缠绕·增益':      {type:'aura', primary:'#74b2ff', secondary:'#cce0ff', glyph:'链'},
+  'haz:锁链缠绕·反击':      {type:'burst', primary:'#9ad9ff', secondary:'#e3f4ff'},
+  'katz:矛刺':              {type:'beam', primary:'#ff886d', secondary:'#ffd5c6', variant:'spear'},
+  'katz:链式鞭击':          {type:'slash', primary:'#ff586f', secondary:'rgba(255,163,177,0.7)', spark:'#ffd2da', slashes:3},
+  'katz:反复鞭尸':          {type:'slash', primary:'#ff4d9d', secondary:'rgba(255,164,210,0.7)', spark:'#ffd4ec', slashes:5},
+  'katz:终焉礼炮':          {type:'beam', primary:'#ff6f3f', secondary:'#ffc8aa', variant:'cannon', length:180},
+  'katz:必须抹杀一切。。':  {type:'rune', primary:'#ff6666', secondary:'#ffd1d1', variant:'obliterate'},
+  'tusk:骨盾猛击':          {type:'impact', primary:'#d2c4ff', secondary:'#f1ebff'},
+  'tusk:来自深海的咆哮':    {type:'burst', primary:'#84dfff', secondary:'#d3f4ff'},
+  'tusk:战争堡垒':          {type:'aura', primary:'#a0b7ff', secondary:'#dde5ff', glyph:'堡'},
+  'tusk:牛鲨冲撞':          {type:'impact', primary:'#ffe483', secondary:'#fff3bd'},
+  'tusk:拼尽全力保卫队长':  {type:'aura', primary:'#ff9e7f', secondary:'#ffd0c2', glyph:'盾'},
+  'neyla:迅捷射击':         {type:'beam', primary:'#ff7dce', secondary:'#ffd6f0', variant:'rapid'},
+  'neyla:穿刺狙击':         {type:'beam', primary:'#ffdf7c', secondary:'#fff0c1', variant:'sniper', length:200},
+  'neyla:双钩牵制':         {type:'claw', primary:'#ff9a9a', secondary:'#ffd8d8', scratches:2},
+  'neyla:终末之影':         {type:'rune', primary:'#ff9df2', secondary:'#ffd9fa', variant:'doom'},
+  'neyla:执行……':          {type:'beam', primary:'#b3a4ff', secondary:'#e8e2ff', variant:'execution', length:140},
+  'kyn:迅影突刺':           {type:'slash', primary:'#8ef9ff', secondary:'rgba(206,253,255,0.7)', spark:'#f0feff', slashes:2},
+  'kyn:死亡宣告':           {type:'rune', primary:'#ff8383', secondary:'#ffd6d6', variant:'doom'},
+  'kyn:割喉飞刃':           {type:'slash', primary:'#ff5f9f', secondary:'rgba(255,176,212,0.7)', spark:'#ffdff0', slashes:3},
+  'kyn:影杀之舞':           {type:'burst', primary:'#b57dff', secondary:'#e8d6ff', variant:'dance'},
+  'kyn:自我了断。。':       {type:'impact', primary:'#7d95ff', secondary:'#d5deff'},
+};
+function showSkillFx(skillKey, ctx={}){
+  if(!skillKey){ return showAttackFx(ctx); }
+  const config = SKILL_FX_CONFIG[skillKey];
+  if(!config){ return showAttackFx(ctx); }
+  const builder = SKILL_FX_BUILDERS[config.type];
+  if(!builder){ return showAttackFx(ctx); }
+  const anchor = resolveSkillFxAnchor(ctx);
+  if(!anchor){ return null; }
+  const angle = computeSkillFxAngle(anchor, ctx.attacker, typeof ctx.angle === 'number' ? ctx.angle : null);
+  return builder({anchor, angle, config, ctx});
+}
+function showDeathFx(u){
+  if(!u || !battleAreaEl) return;
+  const node = makeEl('fx-death');
+  node.classList.add(u.side === 'player' ? 'player' : 'enemy');
+  const size = Math.max(1, u.size || 1);
+  if(size > 1){ node.classList.add(`size-${size}`); }
+  node.innerHTML = `
+    <div class="piece top"></div>
+    <div class="piece bottom"></div>
+    <div class="crack"></div>
+    <div class="dust"></div>
+  `;
+  const attached = fxAtUnit(u, node);
+  if(attached){
+    onAnimEndRemove(attached, 1200);
+  }
+}
+function spawnFloatText(target,text,{className='', offsetX=0, offsetY=-28, zOffset=0}={}){
+  const anchor = resolveFxAnchor(target);
+  if(!anchor) return null;
+  const el = makeEl(`fx-number fx-float ${className}`.trim(), text);
+  el.style.left = `${anchor.x}px`;
+  el.style.top = `${anchor.y}px`;
+  el.style.setProperty('--fx-offset-x', `${offsetX}px`);
+  el.style.setProperty('--fx-offset-y', `${offsetY}px`);
+  if(zOffset){ el.style.zIndex = String(100 + zOffset); }
+  ensureFxLayer();
+  fxLayer.appendChild(el);
+  onAnimEndRemove(el,900);
+  return el;
+}
+function showDamageFloat(target,hp,sp){
+  if(sp>0){
+    const offsetY = hp>0 ? -20 : -40;
+    spawnFloatText(target,`-${sp}`, {className:'sp damage', offsetY, zOffset:1});
+  }
+  if(hp>0){
+    const offsetY = sp>0 ? -56 : -40;
+    spawnFloatText(target,`-${hp}`, {className:'hp damage', offsetY, zOffset:2});
+  }
+}
+function showGainFloat(target,hp,sp){
+  if(sp>0){
+    const offsetY = hp>0 ? -20 : -40;
+    spawnFloatText(target,`+${sp}`, {className:'sp heal', offsetY, zOffset:1});
+  }
+  if(hp>0){
+    const offsetY = sp>0 ? -56 : -40;
+    spawnFloatText(target,`+${hp}`, {className:'hp heal', offsetY, zOffset:2});
+  }
+}
+function showStatusFloat(target,label,{type='buff', delta=null, offsetY=-72}={}){
+  let text = label;
+  if(delta!==null && delta!==0){
+    const sign = delta>0 ? '+' : '';
+    text += `${sign}${delta}`;
+  }
+  return spawnFloatText(target,text,{className:`status ${type}`, offsetY, zOffset:3});
+}
+function updateStatusStacks(u,key,next,{label,type='buff', offsetY=-72}={}){
+  if(!u || !u.status) return next;
+  const prev = u.status[key] || 0;
+  const value = next;
+  u.status[key] = value;
+  const diff = value - prev;
+  if(diff !== 0){
+    showStatusFloat(u,label,{type, delta: diff, offsetY});
+  }
+  return value;
+}
+function addStatusStacks(u,key,delta,opts){
+  if(!u || !u.status || !delta) return (u && u.status) ? (u.status[key] || 0) : 0;
+  const prev = u.status[key] || 0;
+  return updateStatusStacks(u,key, prev + delta, opts);
 }
 function pulseCell(r,c){ const cell=getCellEl(r,c); if(!cell) return; cell.classList.add('pulse'); setTimeout(()=>cell.classList.remove('pulse'),620); }
 function applyCameraTransform(){
@@ -532,12 +1309,14 @@ function cameraFocusOnCell(r,c,{scale=null, hold=enemyActionCameraLock?0:360, im
     cameraResetTimer = setTimeout(()=> cameraReset(), hold);
   }
 }
-function cameraShake(){
+function cameraShake(intensity='normal'){
   if(!battleAreaEl) return;
-  battleAreaEl.classList.remove('shake');
+  const cls = intensity==='heavy' ? 'shake-heavy' : 'shake';
+  battleAreaEl.classList.remove('shake','shake-heavy');
   void battleAreaEl.offsetWidth;
-  battleAreaEl.classList.add('shake');
-  setTimeout(()=> battleAreaEl && battleAreaEl.classList.remove('shake'), 260);
+  battleAreaEl.classList.add(cls);
+  const duration = intensity==='heavy' ? 360 : 220;
+  setTimeout(()=> battleAreaEl && battleAreaEl.classList.remove(cls), duration);
 }
 function zoomCamera(multiplier, focusEvent=null){
   if(!mapPaneEl) return;
@@ -716,7 +1495,8 @@ async function stageMark(cells){
 function applyStunOrStack(target, layers=1, {reason='', bypass=false}={}){
   const u = target; if(!u || u.hp<=0) return;
   if(bypass){
-    u.status.stunned = Math.max(1, u.status.stunned + 1);
+    const next = Math.max(1, (u.status.stunned||0) + 1);
+    updateStatusStacks(u,'stunned', next, {label:'眩晕', type:'debuff'});
     if(reason) appendLog(`${u.name} 因${reason}，陷入眩晕`);
     return;
   }
@@ -725,7 +1505,8 @@ function applyStunOrStack(target, layers=1, {reason='', bypass=false}={}){
   appendLog(`${u.name} 眩晕叠层 +${layers}（${u._staggerStacks}/${thr}）`);
   if(u._staggerStacks >= thr){
     u._staggerStacks = 0;
-    u.status.stunned = Math.max(1, u.status.stunned + 1);
+    const next = Math.max(1, (u.status.stunned||0) + 1);
+    updateStatusStacks(u,'stunned', next, {label:'眩晕', type:'debuff'});
     if(reason) appendLog(`${u.name} 叠层达到门槛，陷入眩晕`);
   }
 }
@@ -748,7 +1529,7 @@ function applySpDamage(targetOrId, amount, {sourceId=null, reason=null}={}){
   u.sp = Math.max(0, u.sp - amount);
   const delta = before - u.sp;
   if(delta>0){
-    showDamageFloat(u.r,u.c,0,delta);
+    showDamageFloat(u,0,delta);
     if(reason){ appendLog(reason.replace('{delta}', String(delta))); }
     handleSpCrashIfNeeded(u);
     renderAll();
@@ -795,38 +1576,57 @@ function calcOutgoingDamage(attacker, baseDmg, target, skillName){
 function damageUnit(id, hpDmg, spDmg, reason, sourceId=null, opts={}){
   const u = units[id]; if(!u || u.hp<=0) return;
 
-  if(sourceId){
-    const src = units[sourceId];
-    if(src && src.side === u.side){ appendLog(`友伤无效：${src.name} -> ${u.name}`); return; }
+  const source = sourceId ? units[sourceId] : null;
+  const buffStage = opts.buffStage || 'final';
+  let trueDamage = !!opts.trueDamage;
+
+  if(source){
+    if(source.side === u.side){ appendLog(`友伤无效：${source.name} -> ${u.name}`); return; }
+
+    if(!opts.ignoreJixue && buffStage==='final' && source.status && source.status.jixueStacks>0){
+      if(!source._jixueActivated){
+        appendLog(`${source.name} 的“鸡血”触发：伤害 x2`);
+        source._jixueActivated = true;
+      }
+      hpDmg = Math.round(hpDmg * 2);
+    }
+
+    if(!opts.ignoreDepend && buffStage==='final' && source.status && source.status.dependStacks>0){
+      if(!source._dependUnleash){
+        appendLog(`${source.name} 的“依赖”触发：造成真实伤害`);
+        source._dependUnleash = true;
+      }
+      trueDamage = true;
+    }
   }
+
   // 掩体：远程（距离>1）才被掩体免疫
-  if(sourceId){
-    const src = units[sourceId];
-    if(src && isCoverCell(u.r, u.c) && mdist(src, u) > 1 && !opts.ignoreCover){
+  if(source && !trueDamage){
+    if(isCoverCell(u.r, u.c) && mdist(source, u) > 1 && !opts.ignoreCover){
       appendLog(`${u.name} 处于掩体内，抵御了远距离伤害`);
       return;
     }
   }
   // 力挽狂澜减伤
-  if(u.id==='haz' && u._comeback){
+  if(u.id==='haz' && u._comeback && !trueDamage){
     hpDmg = Math.round(hpDmg * 0.9);
     spDmg = Math.round(spDmg * 0.9);
   }
 
   // 姿态减伤（优先于 Tusk 固有护甲）
-  if(u._stanceType && u._stanceTurns>0 && u._stanceDmgRed>0){
+  if(!trueDamage && u._stanceType && u._stanceTurns>0 && u._stanceDmgRed>0){
     hpDmg = Math.round(hpDmg * (1 - u._stanceDmgRed));
     spDmg = Math.round(spDmg * (1 - u._stanceDmgRed));
   } else {
     // Tusk 固有“骨墙”（若未进入姿态）
-    if(u.id==='tusk' && !opts.ignoreTuskWall){
+    if(!trueDamage && u.id==='tusk' && !opts.ignoreTuskWall){
       hpDmg = Math.round(hpDmg * 0.7);
       spDmg = Math.round(spDmg * 0.7);
     }
   }
 
   // Tusk 替 Haz 承伤
-  if(u.id==='haz'){
+  if(!trueDamage && u.id==='haz'){
     const tusk = units['tusk'];
     if(tusk && tusk.hp>0){
       const redHp = Math.round(hpDmg * 0.5);
@@ -838,22 +1638,43 @@ function damageUnit(id, hpDmg, spDmg, reason, sourceId=null, opts={}){
     }
   }
 
-  if(u.id==='haz' && u.chainShieldTurns>0){
+  if(!trueDamage && u.id==='haz' && u.chainShieldTurns>0){
     hpDmg = Math.round(hpDmg * 0.6);
     spDmg = Math.round(spDmg * 0.6);
   }
-  if(u.passives.includes('toughBody') && !opts.ignoreToughBody){
+  if(!trueDamage && u.passives.includes('toughBody') && !opts.ignoreToughBody){
     hpDmg = Math.round(hpDmg * 0.75);
   }
 
+  const prevHp = u.hp;
   const finalHp = Math.max(0, hpDmg);
   const finalSp = Math.max(0, spDmg);
 
   u.hp = Math.max(0, u.hp - finalHp);
   u.sp = Math.max(0, u.sp - finalSp);
+  const died = prevHp > 0 && u.hp <= 0;
 
+  const totalImpact = finalHp + finalSp;
+  const heavyHit = trueDamage || totalImpact >= 40 || finalHp >= Math.max(18, Math.round(u.maxHp * 0.3));
   appendLog(`${reason} (-${finalHp} HP, -${finalSp} SP)`);
-  cameraShake(); showHitFX(u.r, u.c); showDamageFloat(u.r, u.c, finalHp, finalSp); pulseCell(u.r, u.c);
+  cameraShake(heavyHit ? 'heavy' : 'normal');
+  const skillFxKey = opts.skillFx || (opts.skillName && source ? `${source.id}:${opts.skillName}` : null);
+  if(skillFxKey){
+    const fxCtx = Object.assign({}, opts.skillFxCtx || {});
+    if(fxCtx.attacker === undefined) fxCtx.attacker = source;
+    if(fxCtx.target === undefined) fxCtx.target = u;
+    if(fxCtx.cell === undefined && opts.fxCell) fxCtx.cell = opts.fxCell;
+    if(fxCtx.point === undefined && opts.fxPoint) fxCtx.point = opts.fxPoint;
+    if(opts.skillFxAngle !== undefined) fxCtx.angle = opts.skillFxAngle;
+    fxCtx.trueDamage = trueDamage;
+    fxCtx.heavy = heavyHit;
+    showSkillFx(skillFxKey, fxCtx);
+  } else {
+    showAttackFx({attacker: source, target: u, trueDamage, heavy: heavyHit});
+  }
+  showDamageFloat(u, finalHp, finalSp);
+  pulseCell(u.r, u.c);
+  if(died){ showDeathFx(u); }
 
   // 锁链缠绕 反击（Haz）
   if(sourceId){
@@ -861,6 +1682,7 @@ function damageUnit(id, hpDmg, spDmg, reason, sourceId=null, opts={}){
     if(src && u.chainShieldTurns>0 && u.chainShieldRetaliate>0){
       u.chainShieldRetaliate = 0;
       applySpDamage(src, 10, {sourceId: u.id, reason:`锁链缠绕反击：${src.name} SP -{delta}`});
+      showSkillFx('haz:锁链缠绕·反击',{target:src});
     }
   }
 
@@ -910,7 +1732,7 @@ function playerGunExec(u, desc){
     const tu = getUnitAt(cell.r,cell.c);
     showTrail(muzzle.r, muzzle.c, cell.r, cell.c);
     if(tu && tu.hp>0 && tu.side !== u.side){
-      damageUnit(tu.id,10,5,`${u.name} 的 枪击 命中 ${tu.name}`, u.id);
+      damageUnit(tu.id,10,5,`${u.name} 的 枪击 命中 ${tu.name}`, u.id,{skillFx:`${u.id}:枪击`});
       u.dmgDone += 10;
     }
   }
@@ -920,13 +1742,14 @@ function adoraDagger(u,target){
   if(!target || target.side===u.side){ appendLog('短匕轻挥 目标无效'); return; }
   const dmg = calcOutgoingDamage(u,10,target,'短匕轻挥');
   cameraFocusOnCell(target.r, target.c);
-  damageUnit(target.id, dmg, 5, `${u.name} 用 短匕轻挥 攻击 ${target.name}`, u.id);
+  damageUnit(target.id, dmg, 5, `${u.name} 用 短匕轻挥 攻击 ${target.name}`, u.id,{skillFx:'adora:短匕轻挥'});
   u.dmgDone += dmg; unitActed(u);
 }
 function adoraPanicMove(u, payload){
   const dest = payload && payload.moveTo; if(!dest){ appendLog('无效的目的地'); return; }
   cameraFocusOnCell(dest.r, dest.c); showTrail(u.r,u.c,dest.r,dest.c);
   u.r=dest.r; u.c=dest.c; pulseCell(u.r,u.c);
+  showSkillFx('adora:呀！你不要靠近我呀！！',{target:u});
   for(const d of Object.keys(DIRS)){
     const cell = forwardCellAt(u,d,1); if(!cell) continue;
     const t = getUnitAt(cell.r,cell.c);
@@ -937,29 +1760,41 @@ function adoraPanicMove(u, payload){
 function adoraZap(u,target){
   if(!target || target.side===u.side){ appendLog('电击装置 目标无效'); return; }
   cameraFocusOnCell(target.r, target.c);
-  damageUnit(target.id,10,15,`${u.name} 自制粉色迷你电击装置 命中 ${target.name}`, u.id);
+  damageUnit(target.id,10,15,`${u.name} 自制粉色迷你电击装置 命中 ${target.name}`, u.id,{skillFx:'adora:自制粉色迷你电击装置'});
   applyStunOrStack(target, 1, {reason:'电击装置'});
-  target.status.paralyzed = (target.status.paralyzed||0) + 1;
+  addStatusStacks(target,'paralyzed',1,{label:'恐惧', type:'debuff'});
   appendLog(`${target.name} 下回合 -1 步`);
   u.dmgDone += 10; unitActed(u);
+}
+function adoraCheer(u, aim){
+  const t = getUnitAt(aim.r, aim.c);
+  if(!t || t.side!==u.side){ appendLog('加油哇！ 目标无效'); return; }
+  if(t.status.jixueStacks>0){ appendLog(`${t.name} 已经处于“鸡血”状态`); return; }
+  updateStatusStacks(t,'jixueStacks',1,{label:'鸡血', type:'buff'});
+  pulseCell(t.r,t.c);
+  showSkillFx('adora:加油哇！',{target:t});
+  appendLog(`${u.name} 对 ${t.name} 使用 加油哇！：赋予 1 层“鸡血”`);
+  unitActed(u);
 }
 function darioClaw(u,target){
   if(!target || target.side===u.side){ appendLog('机械爪击 目标无效'); return; }
   const dmg = calcOutgoingDamage(u,15,target,'机械爪击');
   cameraFocusOnCell(target.r, target.c);
-  damageUnit(target.id, dmg, 0, `${u.name} 发动 机械爪击 ${target.name}`, u.id);
+  damageUnit(target.id, dmg, 0, `${u.name} 发动 机械爪击 ${target.name}`, u.id,{skillFx:'dario:机械爪击'});
   u.dmgDone += dmg; unitActed(u);
 }
 function darioSwiftMove(u, payload){
   const dest = payload && payload.moveTo; if(!dest){ appendLog('无效的目的地'); return; }
   cameraFocusOnCell(dest.r, dest.c); showTrail(u.r,u.c,dest.r,dest.c);
   u.r=dest.r; u.c=dest.c; pulseCell(u.r,u.c);
+  showSkillFx('dario:迅捷步伐',{target:u});
   const enemies = Object.values(units).filter(x=>x.side!==u.side && x.hp>0);
   if(enemies.length){
     let target=null, best=1e9;
     for(const e of enemies){ const d=mdist(u,e); if(d<best){best=d; target=e;} }
     const reduced = applySpDamage(target, 5, {sourceId:u.id});
     appendLog(`${target.name} SP -${reduced}（迅捷步伐）`);
+    showSkillFx('dario:迅捷步伐',{target:target});
   }
   unitActed(u);
 }
@@ -985,18 +1820,36 @@ function darioPull(u, targetOrDesc){
     }
   }
   const dmg = calcOutgoingDamage(u,20,target,'拿来吧你！');
-  damageUnit(target.id, dmg, 0, `${u.name} 的 拿来吧你！ 命中 ${target.name}`, u.id);
+  damageUnit(target.id, dmg, 0, `${u.name} 的 拿来吧你！ 命中 ${target.name}`, u.id,{skillFx:'dario:拿来吧你！'});
   applyStunOrStack(target, 1, {reason:'拉扯冲击'});
   const reduced = applySpDamage(target, 15, {sourceId: u.id});
   appendLog(`${target.name} SP -${reduced}`);
   u.dmgDone += dmg; unitActed(u);
 }
+function darioSweetAfterBitter(u){
+  playerBonusStepsNextTurn += 4;
+  appendLog(`${u.name} 使用 先苦后甜：下个玩家回合 +4 步`);
+  showSkillFx('dario:先苦后甜',{target:u});
+  unitActed(u);
+}
+function adoraDepend(u, aim){
+  const t = getUnitAt(aim.r, aim.c);
+  if(!t || t.side!==u.side){ appendLog('只能靠你了。。 目标无效'); return; }
+  if(t.status.dependStacks>0){ appendLog(`${t.name} 已经处于“依赖”状态`); return; }
+  damageUnit(u.id, 25, 0, `${u.name} 牺牲自身 25 HP`, null, {trueDamage:true, ignoreJixue:true, ignoreDepend:true, skillFx:'adora:只能靠你了。。', skillFxCtx:{target:u}});
+  updateStatusStacks(t,'dependStacks',1,{label:'依赖', type:'buff'});
+  pulseCell(t.r,t.c);
+  showSkillFx('adora:只能靠你了。。',{target:t});
+  appendLog(`${u.name} 对 ${t.name} 施加“依赖”：下一次攻击造成真实伤害并清空自身SP`);
+  unitActed(u);
+}
 function karmaObeyMove(u, payload){
   const dest = payload && payload.moveTo; if(!dest){ appendLog('无效的目的地'); return; }
   cameraFocusOnCell(dest.r, dest.c); showTrail(u.r,u.c,dest.r,dest.c);
   u.r = dest.r; u.c = dest.c; pulseCell(u.r,u.c);
+  showSkillFx('karma:都听你的',{target:u});
   if(u.consecAttacks > 0){ appendLog(`${u.name} 的连击被打断（移动）`); u.consecAttacks = 0; }
-  u.sp = Math.min(u.maxSp, u.sp + 5); u._spBroken = (u.sp<=0); showGainFloat(u.r,u.c,0,5);
+  u.sp = Math.min(u.maxSp, u.sp + 5); u._spBroken = (u.sp<=0); showGainFloat(u,0,5);
   unitActed(u);
 }
 function karmaGrip(u,target){
@@ -1008,18 +1861,47 @@ function karmaGrip(u,target){
   else if(target.id==='kyn' || target.id==='neyla') fixed = 100;
   if(fixed!==null){
     const deal = Math.min(target.hp, fixed);
-    damageUnit(target.id, deal, 0, `${u.name} 嗜血之握 重创 ${target.name}`, u.id, {ignoreToughBody:true, ignoreTuskWall:true});
+    damageUnit(target.id, deal, 0, `${u.name} 嗜血之握 重创 ${target.name}`, u.id, {ignoreToughBody:true, ignoreTuskWall:true, skillFx:'karma:嗜血之握'});
   } else {
-    damageUnit(target.id, target.hp, 0, `${u.name} 嗜血之握 处决 ${target.name}`, u.id, {ignoreToughBody:true});
+    damageUnit(target.id, target.hp, 0, `${u.name} 嗜血之握 处决 ${target.name}`, u.id, {ignoreToughBody:true, skillFx:'karma:嗜血之握'});
   }
   unitActed(u);
 }
-function unitActed(u){ u.actionsThisTurn = Math.max(0, (u.actionsThisTurn||0)+1); }
+function unitActed(u){
+  if(!u) return;
+  u.actionsThisTurn = Math.max(0, (u.actionsThisTurn||0)+1);
+
+  if(u._jixueActivated){
+    if(u.status && u.status.jixueStacks>0){
+      u.status.jixueStacks = Math.max(0, u.status.jixueStacks - 1);
+      appendLog(`${u.name} 的“鸡血”消散`);
+    }
+    u._jixueActivated = false;
+  }
+
+  if(u._dependUnleash){
+    if(u.status && u.status.dependStacks>0){
+      u.status.dependStacks = 0;
+      const beforeSp = u.sp;
+      u.sp = 0;
+      u._spBroken = (u.sp<=0);
+      if(beforeSp>0){
+        appendLog(`${u.name} 的“依赖”消散：SP 清空`);
+        showDamageFloat(u,0,beforeSp);
+      } else {
+        appendLog(`${u.name} 的“依赖”消散：SP 已为 0`);
+      }
+      handleSpCrashIfNeeded(u);
+      renderAll();
+    }
+    u._dependUnleash = false;
+  }
+}
 function karmaPunch(u,target){
   if(!target || target.side===u.side){ appendLog('沙包大的拳头 目标无效'); return; }
   const dmg = calcOutgoingDamage(u, 15, target, '沙包大的拳头');
   cameraFocusOnCell(target.r, target.c);
-  damageUnit(target.id, dmg, 0, `${u.name} 出拳 ${target.name}`, u.id);
+  damageUnit(target.id, dmg, 0, `${u.name} 出拳 ${target.name}`, u.id,{skillFx:'karma:沙包大的拳头'});
   u.dmgDone += dmg; u.consecAttacks = (u.consecAttacks||0)+1; unitActed(u);
 }
 
@@ -1040,7 +1922,7 @@ async function katz_RepeatedWhip(u, desc){
     for(const c of cells){
       const tu=getUnitAt(c.r,c.c);
       if(tu && tu.side!=='enemy' && !hitSet1.has(tu.id)){
-        damageUnit(tu.id, 10, 0, `${u.name} 反复鞭尸·第${cycle}次 第一鞭 命中 ${tu.name}`, u.id);
+        damageUnit(tu.id, 10, 0, `${u.name} 反复鞭尸·第${cycle}次 第一鞭 命中 ${tu.name}`, u.id,{skillFx:'katz:反复鞭尸'});
         hitSet1.add(tu.id); hits1++;
       }
     }
@@ -1049,7 +1931,7 @@ async function katz_RepeatedWhip(u, desc){
     for(const c of cells){
       const tu=getUnitAt(c.r,c.c);
       if(tu && tu.side!=='enemy' && !hitSet2.has(tu.id)){
-        damageUnit(tu.id, 15, 0, `${u.name} 反复鞭尸·第${cycle}次 第二鞭 重击 ${tu.name}`, u.id);
+        damageUnit(tu.id, 15, 0, `${u.name} 反复鞭尸·第${cycle}次 第二鞭 重击 ${tu.name}`, u.id,{skillFx:'katz:反复鞭尸'});
         hitSet2.add(tu.id); hits2++;
       }
     }
@@ -1057,7 +1939,7 @@ async function katz_RepeatedWhip(u, desc){
     const beforeSP = u.sp;
     u.sp = Math.min(u.maxSp, u.sp + 5);
     u._spBroken = (u.sp<=0);
-    showGainFloat(u.r,u.c,0,u.sp-beforeSP);
+    showGainFloat(u,0,u.sp-beforeSP);
     totalHits += hits1 + hits2;
   }
   appendLog(`反复鞭尸 累计命中段数：${totalHits}`);
@@ -1072,7 +1954,7 @@ async function katz_EndSalvo(u, desc){
   for(const c of cells){
     const tu=getUnitAt(c.r,c.c);
     if(tu && tu.side!=='enemy' && !set.has(tu.id)){
-      damageUnit(tu.id, 35, 0, `${u.name} 终焉礼炮 命中 ${tu.name}`, u.id, {ignoreCover:true});
+      damageUnit(tu.id, 35, 0, `${u.name} 终焉礼炮 命中 ${tu.name}`, u.id, {ignoreCover:true, skillFx:'katz:终焉礼炮'});
       set.add(tu.id); hits++;
     }
   }
@@ -1089,9 +1971,10 @@ function adoraFieldMedic(u, aim){
   t.hp = Math.min(t.maxHp, t.hp + 20);
   t.sp = Math.min(t.maxSp, t.sp + 15);
   t._spBroken = (t.sp<=0);
-  t.status.recoverStacks = (t.status.recoverStacks || 0) + 1;
-  appendLog(`${u.name} 对 ${t.name} 使用 略懂的医术！：+20HP +15SP，并赋予“恢复”(${t.status.recoverStacks})`);
-  showGainFloat(t.r,t.c,t.hp-hpBefore,t.sp-spBefore);
+  const stacks = addStatusStacks(t,'recoverStacks',1,{label:'恢复', type:'buff'});
+  appendLog(`${u.name} 对 ${t.name} 使用 略懂的医术！：+20HP +15SP，并赋予“恢复”(${stacks})`);
+  showGainFloat(t,t.hp-hpBefore,t.sp-spBefore);
+  showSkillFx('adora:略懂的医术！',{target:t});
   unitActed(u);
 }
 // Karma：深呼吸（25级，白色）
@@ -1100,7 +1983,8 @@ function karmaDeepBreath(u){
   u.sp = u.maxSp; u._spBroken = (u.sp<=0);
   u.hp = Math.min(u.maxHp, u.hp + 10);
   appendLog(`${u.name} 使用 深呼吸：SP回满，+10HP（被动+10%仅在手牌中未被使用时生效）`);
-  showGainFloat(u.r,u.c,u.hp-hpBefore,u.sp-spBefore);
+  showGainFloat(u,u.hp-hpBefore,u.sp-spBefore);
+  showSkillFx('karma:深呼吸',{target:u});
   unitActed(u);
 }
 
@@ -1111,14 +1995,15 @@ async function haz_HarpoonStab(u, target){
   await telegraphThenImpact(cells);
   const dmg = calcOutgoingDamage(u,20,target,'鱼叉穿刺');
   cameraFocusOnCell(target.r, target.c);
-  damageUnit(target.id, dmg, 0, `${u.name} 鱼叉穿刺 命中 ${target.name}`, u.id);
-  u.sp = Math.min(u.maxSp, u.sp + 10); u._spBroken = (u.sp<=0); showGainFloat(u.r,u.c,0,10);
+  damageUnit(target.id, dmg, 0, `${u.name} 鱼叉穿刺 命中 ${target.name}`, u.id,{skillFx:'haz:鱼叉穿刺'});
+  u.sp = Math.min(u.maxSp, u.sp + 10); u._spBroken = (u.sp<=0); showGainFloat(u,0,10);
   if(!hazMarkedTargetId){ hazMarkedTargetId = target.id; appendLog(`猎杀标记：${target.name} 被标记，七海对其伤害 +15%`); }
   if(Math.random() < 0.4){
     const reduced = applySpDamage(target,5,{sourceId:u.id});
     appendLog(`${target.name} SP -${reduced}（恐惧）`);
-    target.status.paralyzed = (target.status.paralyzed||0) + 1;
+    addStatusStacks(target,'paralyzed',1,{label:'恐惧', type:'debuff'});
     appendLog(`${target.name} 下回合 -1 步`);
+    showSkillFx('haz:怨念滋生·恐惧',{target:target});
   }
   u.dmgDone += dmg; unitActed(u);
 }
@@ -1131,7 +2016,7 @@ async function haz_DeepHunt(u, desc){
   if(!target){ appendLog('深海猎杀 未找到目标'); return; }
   const dmg = calcOutgoingDamage(u,25,target,'深海猎杀');
   cameraFocusOnCell(target.r, target.c);
-  damageUnit(target.id, dmg, 0, `${u.name} 深海猎杀 命中 ${target.name}`, u.id);
+  damageUnit(target.id, dmg, 0, `${u.name} 深海猎杀 命中 ${target.name}`, u.id,{skillFx:'haz:深海猎杀'});
   const front = forwardCellAt(u, dir, 1);
   if(front && !getUnitAt(front.r, front.c)){ target.r = front.r; target.c = front.c; pulseCell(front.r, front.c); appendLog(`${target.name} 被拉至面前一格`); }
   const reduced = applySpDamage(target,10,{sourceId:u.id});
@@ -1149,20 +2034,24 @@ async function haz_GodFork(u, target){
   let dmg = calcOutgoingDamage(u,20,target,'猎神之叉');
   if(Math.random()<0.5){ dmg = Math.round(dmg*2.0); appendLog('猎神之叉 暴怒加成 x2.0'); }
   cameraFocusOnCell(target.r, target.c);
-  damageUnit(target.id, dmg, 15, `${u.name} 猎神之叉 重击 ${target.name}`, u.id);
-  target.status.bleed = Math.max(target.status.bleed||0, 2); appendLog(`${target.name} 附加流血（2回合，每回合 -5%最大HP）`);
+  damageUnit(target.id, dmg, 15, `${u.name} 猎神之叉 重击 ${target.name}`, u.id,{skillFx:'haz:猎神之叉'});
+  const bleedStacks = Math.max(target.status.bleed||0, 2);
+  updateStatusStacks(target,'bleed', bleedStacks,{label:'流血', type:'debuff'});
+  appendLog(`${target.name} 附加流血（2回合，每回合 -5%最大HP）`);
   if(!hazMarkedTargetId){ hazMarkedTargetId = target.id; appendLog(`猎杀标记：${target.name} 被标记，七海对其伤害 +15%`); }
   u.dmgDone += dmg; unitActed(u);
 }
 function haz_ChainShield(u){
   u.chainShieldTurns = 2; u.chainShieldRetaliate = 1;
   appendLog(`${u.name} 锁链缠绕：2回合内伤害-40%，下次被打反击 10SP`);
+  showSkillFx('haz:锁链缠绕',{target:u});
   for(const id in units){
     const v=units[id];
     if(v.team==='seven' && v.hp>0){
       v.sp = Math.min(v.maxSp, v.sp+5);
       v._spBroken = (v.sp<=0);
-      showGainFloat(v.r,v.c,0,5);
+      showGainFloat(v,0,5);
+      showSkillFx('haz:锁链缠绕·增益',{target:v});
     }
   }
   unitActed(u);
@@ -1174,8 +2063,8 @@ async function haz_WhaleFall(u){
   for(const c of cells){
     const tu = getUnitAt(c.r,c.c);
     if(tu && tu.side!=='enemy' && !set.has(tu.id)){
-      damageUnit(tu.id, 50, 20, `${u.name} 鲸落 轰击 ${tu.name}`, u.id, {ignoreCover:true});
-      tu.status.paralyzed = (tu.status.paralyzed||0) + 1;
+      damageUnit(tu.id, 50, 20, `${u.name} 鲸落 轰击 ${tu.name}`, u.id, {ignoreCover:true, skillFx:'haz:鲸落'});
+      addStatusStacks(tu,'paralyzed',1,{label:'恐惧', type:'debuff'});
       set.add(tu.id); hits++;
     }
   }
@@ -1189,14 +2078,14 @@ async function haz_PayThePrice(u, desc){
   const L1 = range_forward_n(u,3,dir);
   await telegraphThenImpact(L1);
   let h1=0;
-  for(const c of L1){ const tu=getUnitAt(c.r,c.c); showTrail(u.r,u.c,c.r,c.c); if(tu && tu.side!=='enemy'){ damageUnit(tu.id,15,0,`${u.name} 付出代价·前刺 命中 ${tu.name}`, u.id); h1++; } }
+  for(const c of L1){ const tu=getUnitAt(c.r,c.c); showTrail(u.r,u.c,c.r,c.c); if(tu && tu.side!=='enemy'){ damageUnit(tu.id,15,0,`${u.name} 付出代价·前刺 命中 ${tu.name}`, u.id,{skillFx:'haz:付出代价'}); h1++; } }
   await stageMark(L1);
 
   // 段2：穿刺（前4）
   const L2 = range_forward_n(u,4,dir);
   await telegraphThenImpact(L2);
   let h2=0;
-  for(const c of L2){ const tu=getUnitAt(c.r,c.c); showTrail(u.r,u.c,c.r,c.c); if(tu && tu.side!=='enemy'){ damageUnit(tu.id,15,5,`${u.name} 付出代价·穿刺 命中 ${tu.name}`, u.id); h2++; } }
+  for(const c of L2){ const tu=getUnitAt(c.r,c.c); showTrail(u.r,u.c,c.r,c.c); if(tu && tu.side!=='enemy'){ damageUnit(tu.id,15,5,`${u.name} 付出代价·穿刺 命中 ${tu.name}`, u.id,{skillFx:'haz:付出代价'}); h2++; } }
   await stageMark(L2);
 
   // 段3：横斩（横3x前2）
@@ -1206,8 +2095,9 @@ async function haz_PayThePrice(u, desc){
   for(const c of R){
     const tu=getUnitAt(c.r,c.c);
     if(tu && tu.side!=='enemy' && !seen.has(tu.id)){
-      damageUnit(tu.id,15,0,`${u.name} 付出代价·横斩 命中 ${tu.name}`, u.id);
-      tu.status.hazBleedTurns = 2; appendLog(`${tu.name} 附加 Haz流血(2)`); seen.add(tu.id); h3++;
+      damageUnit(tu.id,15,0,`${u.name} 付出代价·横斩 命中 ${tu.name}`, u.id,{skillFx:'haz:付出代价'});
+      updateStatusStacks(tu,'hazBleedTurns',2,{label:'Haz流血', type:'debuff'});
+      appendLog(`${tu.name} 附加 Haz流血(2)`); seen.add(tu.id); h3++;
     }
   }
   appendLog(`付出代价：前刺${h1}/穿刺${h2}/横斩${h3}`);
@@ -1223,7 +2113,7 @@ async function haz_ForkOfHatred(u, desc){
   for(const c of R){
     const tu=getUnitAt(c.r,c.c);
     if(tu && tu.side!=='enemy' && !seen1.has(tu.id)){
-      damageUnit(tu.id,15,10,`${u.name} 仇恨之叉·横斩 命中 ${tu.name}`, u.id);
+      damageUnit(tu.id,15,10,`${u.name} 仇恨之叉·横斩 命中 ${tu.name}`, u.id,{skillFx:'haz:仇恨之叉'});
       seen1.add(tu.id); h1++;
     }
   }
@@ -1236,8 +2126,9 @@ async function haz_ForkOfHatred(u, desc){
   for(const c of AOE){
     const tu=getUnitAt(c.r,c.c);
     if(tu && tu.side!=='enemy' && !seen2.has(tu.id)){
-      damageUnit(tu.id,20,0,`${u.name} 仇恨之叉·重砸 命中 ${tu.name}`, u.id, {ignoreCover:true});
-      tu.status.hazBleedTurns = 2; appendLog(`${tu.name} 附加 Haz流血(2)`);
+      damageUnit(tu.id,20,0,`${u.name} 仇恨之叉·重砸 命中 ${tu.name}`, u.id, {ignoreCover:true, skillFx:'haz:仇恨之叉'});
+      updateStatusStacks(tu,'hazBleedTurns',2,{label:'Haz流血', type:'debuff'});
+      appendLog(`${tu.name} 附加 Haz流血(2)`);
       seen2.add(tu.id); h2++;
     }
   }
@@ -1251,8 +2142,8 @@ async function katz_Thrust(u,target){
   await telegraphThenImpact([{r:target.r,c:target.c}]);
   let dmg = calcOutgoingDamage(u,20,target,'矛刺');
   cameraFocusOnCell(target.r,target.c);
-  damageUnit(target.id, dmg, 0, `${u.name} 矛刺 命中 ${target.name}`, u.id);
-  u.sp = Math.min(u.maxSp, u.sp+5); u._spBroken = (u.sp<=0); showGainFloat(u.r,u.c,0,5);
+  damageUnit(target.id, dmg, 0, `${u.name} 矛刺 命中 ${target.name}`, u.id,{skillFx:'katz:矛刺'});
+  u.sp = Math.min(u.maxSp, u.sp+5); u._spBroken = (u.sp<=0); showGainFloat(u,0,5);
   u.dmgDone += dmg; unitActed(u);
 }
 async function katz_ChainWhip(u,desc){
@@ -1263,8 +2154,8 @@ async function katz_ChainWhip(u,desc){
   for(const c of cells){
     const tu=getUnitAt(c.r,c.c);
     if(tu && tu.side!=='enemy' && !set.has(tu.id)){
-      damageUnit(tu.id,25,0,`${u.name} 链式鞭击 命中 ${tu.name}`, u.id);
-      tu.status.paralyzed = (tu.status.paralyzed||0) + 1;
+      damageUnit(tu.id,25,0,`${u.name} 链式鞭击 命中 ${tu.name}`, u.id,{skillFx:'katz:链式鞭击'});
+      addStatusStacks(tu,'paralyzed',1,{label:'恐惧', type:'debuff'});
       set.add(tu.id); hits++;
     }
   }
@@ -1282,13 +2173,13 @@ async function katz_MustErase(u, desc){
     for(const c of cells){
       const tu=getUnitAt(c.r,c.c);
       if(tu && tu.side!=='enemy' && !set.has(tu.id)){
-        damageUnit(tu.id, dmg, 0, `${u.name} 必须抹杀一切.. 第${cycle}段 命中 ${tu.name}`, u.id);
+        damageUnit(tu.id, dmg, 0, `${u.name} 必须抹杀一切.. 第${cycle}段 命中 ${tu.name}`, u.id,{skillFx:'katz:必须抹杀一切。。'});
         set.add(tu.id); hits++;
       }
     }
     if(hits>0){
-      u.hp = Math.max(1, u.hp - 5); showDamageFloat(u.r,u.c,5,0);
-      u.sp = Math.min(u.maxSp, u.sp + 5); u._spBroken = (u.sp<=0); showGainFloat(u.r,u.c,0,5);
+      u.hp = Math.max(1, u.hp - 5); showDamageFloat(u,5,0);
+      u.sp = Math.min(u.maxSp, u.sp + 5); u._spBroken = (u.sp<=0); showGainFloat(u,0,5);
       await stageMark(cells);
     }
   }
@@ -1301,7 +2192,7 @@ async function tusk_ShieldBash(u,target){
   await telegraphThenImpact([{r:target.r,c:target.c}]);
   const dmg = calcOutgoingDamage(u,10,target,'骨盾猛击');
   cameraFocusOnCell(target.r,target.c);
-  damageUnit(target.id, dmg, 0, `${u.name} 骨盾猛击 ${target.name}`, u.id);
+  damageUnit(target.id, dmg, 0, `${u.name} 骨盾猛击 ${target.name}`, u.id,{skillFx:'tusk:骨盾猛击'});
   const dir = cardinalDirFromDelta(target.r-u.r, target.c-u.c);
   const back = forwardCellAt(target, dir, 1);
   if(back && !getUnitAt(back.r, back.c)){ target.r=back.r; target.c=back.c; pulseCell(back.r,back.c); appendLog(`${target.name} 被击退一格`); }
@@ -1316,9 +2207,11 @@ async function tusk_DeepRoar(u){
     if(tu && tu.side!=='enemy' && !set.has(tu.id)){
       const reduced = applySpDamage(tu, 20, {sourceId:u.id});
       appendLog(`${tu.name} 因咆哮 SP -${reduced}`);
+      showSkillFx('tusk:来自深海的咆哮',{target:tu});
       set.add(tu.id); hits++;
     }
   }
+  showSkillFx('tusk:来自深海的咆哮',{target:u});
   appendLog(`来自深海的咆哮 命中 ${hits} 人`);
   unitActed(u);
 }
@@ -1339,11 +2232,13 @@ function clearStance(u){
 function tusk_WarFortress(u){
   // 防御姿态：减伤50%，每回合+10SP，3回合；期间无法移动
   enterStance(u, 'defense', 3, {dmgReduction:0.5, spPerTurn:10});
+  showSkillFx('tusk:战争堡垒',{target:u});
   unitActed(u);
 }
 function tusk_RetaliateGuard(u){
   // 反伤姿态：减伤40%，每回合+10SP，反弹30%所受HP伤害，3回合；期间无法移动
   enterStance(u, 'retaliate', 3, {dmgReduction:0.4, spPerTurn:10, reflectPct:0.3});
+  showSkillFx('tusk:拼尽全力保卫队长',{target:u});
   unitActed(u);
 }
 async function tusk_BullCharge(u, desc){
@@ -1364,7 +2259,7 @@ async function tusk_BullCharge(u, desc){
     if(lastFree){ showTrail(u.r,u.c,lastFree.r,lastFree.c); u.r=lastFree.r; u.c=lastFree.c; pulseCell(u.r,u.c); }
     const dmg = calcOutgoingDamage(u,20,hitTarget,'牛鲨冲撞');
     cameraFocusOnCell(hitTarget.r, hitTarget.c);
-    damageUnit(hitTarget.id, dmg, 0, `${u.name} 牛鲨冲撞 命中并撞击 ${hitTarget.name}`, u.id);
+    damageUnit(hitTarget.id, dmg, 0, `${u.name} 牛鲨冲撞 命中并撞击 ${hitTarget.name}`, u.id,{skillFx:'tusk:牛鲨冲撞'});
     const knockDir = cardinalDirFromDelta(hitTarget.r - u.r, hitTarget.c - u.c);
     const back = forwardCellAt(hitTarget, knockDir, 1);
     if(back && !getUnitAt(back.r, back.c)){ hitTarget.r=back.r; hitTarget.c=back.c; pulseCell(back.r, back.c); appendLog(`${hitTarget.name} 被撞退一格`); }
@@ -1394,7 +2289,7 @@ async function neyla_SwiftShot(u, targetOrAim){
   if(tu.hp <= tu.maxHp/2) base = base*2;
   const dmg = calcOutgoingDamage(u,base,tu,'迅捷射击');
   cameraFocusOnCell(tu.r, tu.c);
-  damageUnit(tu.id, dmg, 5, `${u.name} 迅捷射击 命中 ${tu.name}`, u.id);
+  damageUnit(tu.id, dmg, 5, `${u.name} 迅捷射击 命中 ${tu.name}`, u.id,{skillFx:'neyla:迅捷射击'});
   unitActed(u);
 }
 async function neyla_PierceSnipe(u, desc){
@@ -1405,8 +2300,9 @@ async function neyla_PierceSnipe(u, desc){
   for(const c of line){
     const tu=getUnitAt(c.r,c.c);
     if(tu && tu.side!=='enemy' && !set.has(tu.id)){
-      damageUnit(tu.id,30,0,`${u.name} 穿刺狙击 命中 ${tu.name}`, u.id);
-      tu.status.bleed = Math.max(tu.status.bleed||0, 2);
+      damageUnit(tu.id,30,0,`${u.name} 穿刺狙击 命中 ${tu.name}`, u.id,{skillFx:'neyla:穿刺狙击'});
+      const bleedNext = Math.max(tu.status.bleed||0, 2);
+      updateStatusStacks(tu,'bleed', bleedNext,{label:'流血', type:'debuff'});
       set.add(tu.id); hits++;
     }
   }
@@ -1418,7 +2314,7 @@ async function neyla_EndShadow(u, aim){
   if(!tu || tu.side==='enemy') { appendLog('终末之影 未命中'); unitActed(u); return; }
   await telegraphThenImpact([{r:tu.r,c:tu.c}]);
   cameraFocusOnCell(tu.r, tu.c);
-  damageUnit(tu.id, 50, 20, `${u.name} 终末之影 命中 ${tu.name}`, u.id);
+  damageUnit(tu.id, 50, 20, `${u.name} 终末之影 命中 ${tu.name}`, u.id,{skillFx:'neyla:终末之影'});
   unitActed(u);
 }
 // Neyla：双钩牵制（2步，红，前3格内优先最近，单体）
@@ -1437,11 +2333,87 @@ async function neyla_DoubleHook(u, desc){
     target.r = stepCell.r; target.c = stepCell.c; pulseCell(target.r,target.c);
     appendLog(`${target.name} 被双钩拉近一格`);
   }
-  target.status.paralyzed = (target.status.paralyzed||0) + 1;
+  addStatusStacks(target,'paralyzed',1,{label:'恐惧', type:'debuff'});
   appendLog(`${target.name} 因双钩牵制：下回合 -1 步`);
   const dmg = calcOutgoingDamage(u,15,target,'双钩牵制');
-  damageUnit(target.id, dmg, 0, `${u.name} 双钩牵制 命中 ${target.name}`, u.id);
+  damageUnit(target.id, dmg, 0, `${u.name} 双钩牵制 命中 ${target.name}`, u.id,{skillFx:'neyla:双钩牵制'});
+  showSkillFx('neyla:双钩牵制',{target:target});
   u.dmgDone += dmg; unitActed(u);
+}
+
+async function neyla_ExecuteHarpoons(u, desc){
+  const dir = (desc && desc.dir) ? desc.dir : u.facing;
+  const line = range_line(u, dir);
+  if(line.length===0){ appendLog('执行……：前方没有可以射击的目标'); unitActed(u); return; }
+  await telegraphThenImpact(line);
+  const targets=[]; const seen=new Set();
+  for(const cell of line){
+    const tu = getUnitAt(cell.r, cell.c);
+    if(tu && tu.side!=='enemy' && !seen.has(tu.id)){
+      targets.push(tu);
+      seen.add(tu.id);
+    }
+  }
+  if(targets.length>0){ cameraFocusOnCell(targets[0].r, targets[0].c); }
+  const applySelfCost = (hpCost, spCost, stageLabel)=>{
+    let lostHp = 0;
+    if(hpCost>0 && u.hp>0){
+      const before = u.hp;
+      u.hp = Math.max(0, u.hp - hpCost);
+      lostHp = before - u.hp;
+      if(lostHp>0){
+        appendLog(`${u.name} ${stageLabel} 反噬：HP -${lostHp}`);
+        showDamageFloat(u, lostHp, 0);
+        pulseCell(u.r, u.c);
+        if(before>0 && u.hp<=0){ showDeathFx(u); }
+      }
+    }
+    if(spCost>0){
+      applySpDamage(u, spCost, {reason:`${u.name} ${stageLabel} 反噬：SP -{delta}`});
+    }
+    if(lostHp>0){ renderAll(); }
+    return {lostHp};
+  };
+
+  let firstHits = 0;
+  for(const target of targets){
+    if(target.hp<=0) continue;
+    const dmg = calcOutgoingDamage(u,20,target,'执行……·第一枪');
+    damageUnit(target.id, dmg, 0, `${u.name} 执行……·第一枪 命中 ${target.name}`, u.id,{skillFx:'neyla:执行……'});
+    u.dmgDone += dmg;
+    firstHits++;
+  }
+  if(firstHits>0){ appendLog(`执行……·第一枪 命中 ${firstHits} 人`); }
+  else { appendLog('执行……·第一枪 未命中任何目标'); }
+  applySelfCost(15, 0, '第一枪');
+  await stageMark(line);
+  if(u.hp<=0){ unitActed(u); return; }
+  await sleep(180);
+
+  let secondHits = 0; let executeCount = 0;
+  for(const target of targets){
+    if(target.hp<=0) continue;
+    const executeThreshold = Math.ceil(target.maxHp * 0.15);
+    if(target.hp <= executeThreshold){
+      const lethal = target.hp;
+      damageUnit(target.id, lethal, 0, `${u.name} 执行……·第二枪 处决 ${target.name}`, u.id,{skillFx:'neyla:执行……', trueDamage:true, ignoreCover:true, ignoreToughBody:true});
+      u.dmgDone += lethal;
+      executeCount++;
+      secondHits++;
+    } else {
+      const dmg = calcOutgoingDamage(u,20,target,'执行……·第二枪');
+      damageUnit(target.id, dmg, 0, `${u.name} 执行……·第二枪 命中 ${target.name}`, u.id,{skillFx:'neyla:执行……'});
+      u.dmgDone += dmg;
+      secondHits++;
+    }
+  }
+  if(secondHits>0){
+    appendLog(`执行……·第二枪 命中 ${secondHits} 人${executeCount>0 ? `，处决 ${executeCount}` : ''}`);
+  } else {
+    appendLog('执行……·第二枪 未命中任何目标');
+  }
+  applySelfCost(15, 40, '第二枪');
+  unitActed(u);
 }
 
 // —— Kyn —— 
@@ -1464,11 +2436,11 @@ async function kyn_ShadowDash(u, target){
   let executed = false;
 
   if(target.hp<=thresh){
-    damageUnit(target.id, target.hp, 0, `${u.name} 迅影突刺 处决 ${target.name}`, u.id);
+    damageUnit(target.id, target.hp, 0, `${u.name} 迅影突刺 处决 ${target.name}`, u.id,{skillFx:'kyn:迅影突刺'});
     executed = true;
   } else {
     const before = target.hp;
-    damageUnit(target.id, 20, 0, `${u.name} 迅影突刺 命中 ${target.name}`, u.id);
+    damageUnit(target.id, 20, 0, `${u.name} 迅影突刺 命中 ${target.name}`, u.id,{skillFx:'kyn:迅影突刺'});
     if(before>0 && target.hp<=0) executed = true;
   }
   if(u.passives.includes('kynReturn') && executed){
@@ -1483,11 +2455,11 @@ async function kyn_DeathCall(u, target){
   let executed = false;
 
   if(target.hp<=thresh){
-    damageUnit(target.id, target.hp, 0, `${u.name} 死亡宣告 处决 ${target.name}`, u.id);
+    damageUnit(target.id, target.hp, 0, `${u.name} 死亡宣告 处决 ${target.name}`, u.id,{skillFx:'kyn:死亡宣告'});
     executed = true;
   } else {
     const before = target.hp;
-    damageUnit(target.id, 50, 30, `${u.name} 死亡宣告 重创 ${target.name}`, u.id);
+    damageUnit(target.id, 50, 30, `${u.name} 死亡宣告 重创 ${target.name}`, u.id,{skillFx:'kyn:死亡宣告'});
     if(before>0 && target.hp<=0) executed = true;
   }
   if(u.passives.includes('kynReturn') && executed){
@@ -1503,9 +2475,9 @@ async function kyn_ThroatBlade(u, aim){
   await telegraphThenImpact([{r:tu.r,c:tu.c}]);
   const dmg = calcOutgoingDamage(u,20,tu,'割喉飞刃');
   cameraFocusOnCell(tu.r, tu.c);
-  damageUnit(tu.id, dmg, 0, `${u.name} 割喉飞刃 命中 ${tu.name}`, u.id);
-  tu.status.bleed = (tu.status.bleed||0) + 1;
-  tu.status.paralyzed = (tu.status.paralyzed||0) + 1;
+  damageUnit(tu.id, dmg, 0, `${u.name} 割喉飞刃 命中 ${tu.name}`, u.id,{skillFx:'kyn:割喉飞刃'});
+  addStatusStacks(tu,'bleed',1,{label:'流血', type:'debuff'});
+  addStatusStacks(tu,'paralyzed',1,{label:'恐惧', type:'debuff'});
   appendLog(`${tu.name} 附加 流血+1、恐惧+1`);
   unitActed(u);
 }
@@ -1517,7 +2489,7 @@ async function kyn_ShadowDance_AOE(u){
   for(const c of cells){
     const tu=getUnitAt(c.r,c.c);
     if(tu && tu.side!=='enemy' && !seen.has(tu.id)){
-      damageUnit(tu.id, 30, 0, `${u.name} 影杀之舞 横扫 ${tu.name}`, u.id, {ignoreCover:true});
+      damageUnit(tu.id, 30, 0, `${u.name} 影杀之舞 横扫 ${tu.name}`, u.id, {ignoreCover:true, skillFx:'kyn:影杀之舞'});
       seen.add(tu.id); hits++;
     }
   }
@@ -1599,6 +2571,18 @@ function buildSkillFactoriesForUnit(u){
         (uu,aim)=> adoraFieldMedic(uu,aim),
         {aoe:false},
         {cellTargeting:true, castMs:900}
+      )},
+      { key:'加油哇！', prob:0.20, cond:()=>u.level>=25, make:()=> skill('加油哇！',4,'orange','以自身为中心5x5内选择友方：赋予 1 层“鸡血”（下一次攻击伤害翻倍，使用后移除）',
+        (uu)=> range_square_n(uu,2).filter(p=>{ const tu=getUnitAt(p.r,p.c); return tu && tu.side===uu.side; }),
+        (uu,aim)=> adoraCheer(uu,aim),
+        {aoe:false},
+        {cellTargeting:true, castMs:900}
+      )},
+      { key:'只能靠你了。。', prob:0.15, cond:()=>u.level>=35, make:()=> skill('只能靠你了。。',4,'orange','牺牲25HP；以自身为中心5格范围友方，赋予1层“依赖”（下一次攻击造成真实伤害并清空自身SP）',
+        (uu)=> range_square_n(uu,5).filter(p=>{ const tu=getUnitAt(p.r,p.c); return tu && tu.side===uu.side; }),
+        (uu,aim)=> adoraDepend(uu,aim),
+        {aoe:false},
+        {cellTargeting:true, castMs:900}
       )}
     );
   } else if(u.id==='dario'){
@@ -1633,6 +2617,14 @@ function buildSkillFactoriesForUnit(u){
         (uu,desc)=> darioPull(uu,desc),
         {aoe:true},
         {castMs:1100}
+      )}
+    );
+    F.push(
+      { key:'先苦后甜', prob:0.15, cond:()=>u.level>=25 && ((u.skillPool||[]).filter(s=>s && s.name==='先苦后甜').length < 2), make:()=> skill('先苦后甜',4,'orange','自我激励：下个玩家回合额外 +4 步（技能池最多保留2张）',
+        (uu)=>[{r:uu.r,c:uu.c,dir:uu.facing}],
+        (uu)=> darioSweetAfterBitter(uu),
+        {},
+        {castMs:700}
       )}
     );
   } else if(u.id==='karma'){
@@ -1723,7 +2715,7 @@ function buildSkillFactoriesForUnit(u){
         )},
         { key:'怨念滋生', prob:0.33, cond:()=>true, make:()=> skill('怨念滋生',1,'green','全图：对被猎杀标记目标 施加1流血+1恐惧',
           (uu)=>[{r:uu.r,c:uu.c,dir:uu.facing}],
-          (uu)=> { if(!hazMarkedTargetId){ appendLog('怨念滋生：没有被标记的目标'); unitActed(uu); return; } const t=units[hazMarkedTargetId]; if(!t||t.hp<=0){ appendLog('怨念滋生：标记目标不存在或已倒下'); unitActed(uu); return; } addTempClassToCells([{r:t.r,c:t.c}],'highlight-tele',TELEGRAPH_MS); setTimeout(()=>{ t.status.bleed=(t.status.bleed||0)+1; t.status.paralyzed=(t.status.paralyzed||0)+1; appendLog(`${uu.name} 怨念滋生：对 ${t.name} 施加 1层流血 与 1层恐惧`); }, TELEGRAPH_MS); unitActed(uu); },
+        (uu)=> { if(!hazMarkedTargetId){ appendLog('怨念滋生：没有被标记的目标'); unitActed(uu); return; } const t=units[hazMarkedTargetId]; if(!t||t.hp<=0){ appendLog('怨念滋生：标记目标不存在或已倒下'); unitActed(uu); return; } addTempClassToCells([{r:t.r,c:t.c}],'highlight-tele',TELEGRAPH_MS); setTimeout(()=>{ addStatusStacks(t,'bleed',1,{label:'流血', type:'debuff'}); addStatusStacks(t,'paralyzed',1,{label:'恐惧', type:'debuff'}); showSkillFx('haz:怨念滋生',{target:t}); appendLog(`${uu.name} 怨念滋生：对 ${t.name} 施加 1层流血 与 1层恐惧`); }, TELEGRAPH_MS); unitActed(uu); },
           {},
           {castMs:800}
         )},
@@ -1889,7 +2881,7 @@ function buildSkillFactoriesForUnit(u){
       F.push(
         { key:'自我了断。。', prob:0.40, cond:()=>true, make:()=> skill('自我了断。。',2,'red','5x5内任意敌人：瞬杀，自己HP清零（压迫）',
           (uu)=> range_square_n(uu,2),
-          (uu,aim)=>{ const tu=getUnitAt(aim.r,aim.c); if(tu && tu.side!=='enemy'){ damageUnit(tu.id, tu.hp, 0, `${uu.name} 自我了断 秒杀 ${tu.name}`, uu.id); damageUnit(uu.id, uu.hp, 0, `${uu.name} 生命燃尽`, uu.id, {ignoreToughBody:true}); } unitActed(uu); },
+          (uu,aim)=>{ const tu=getUnitAt(aim.r,aim.c); if(tu && tu.side!=='enemy'){ damageUnit(tu.id, tu.hp, 0, `${uu.name} 自我了断 秒杀 ${tu.name}`, uu.id,{skillFx:'kyn:自我了断。。'}); damageUnit(uu.id, uu.hp, 0, `${uu.name} 生命燃尽`, uu.id, {ignoreToughBody:true, skillFx:'kyn:自我了断。。', skillFxCtx:{target:uu}}); } unitActed(uu); },
           {aoe:false},
           {cellTargeting:true, castMs:1100}
         )}
@@ -1942,7 +2934,10 @@ function showGodsWillMenuAtUnit(u){
     const before = u.hp;
     u.hp = 0;
     appendLog(`GOD’S WILL：${u.name} 被直接抹除（-${before} HP）`);
-    cameraShake(); showHitFX(u.r,u.c); showDamageFloat(u.r,u.c,before,0);
+    cameraShake('heavy');
+    showAttackFx({target: u, trueDamage: true, heavy: true});
+    showDamageFloat(u,before,0);
+    if(before>0){ showDeathFx(u); }
     checkHazComebackStatus();
     renderAll();
     disarmGodsWill();
@@ -1953,7 +2948,10 @@ function showGodsWillMenuAtUnit(u){
       const delta = u.hp - 1;
       u.hp = 1;
       appendLog(`GOD’S WILL：${u.name} 被压到 1 HP（-${delta} HP）`);
-      cameraShake(); showHitFX(u.r,u.c); showDamageFloat(u.r,u.c,delta,0);
+      const heavy = delta >= Math.max(18, Math.round(u.maxHp * 0.3));
+      cameraShake(heavy ? 'heavy' : 'normal');
+      showAttackFx({target: u, heavy, trueDamage: true});
+      showDamageFloat(u,delta,0);
     } else {
       appendLog(`GOD’S WILL：${u.name} 已是 1 HP`);
     }
@@ -2019,6 +3017,7 @@ function buildGrid(){
   battleAreaEl.style.setProperty('--cell', `${CELL_SIZE}px`);
   battleAreaEl.style.gridTemplateColumns = `repeat(${COLS}, var(--cell))`;
   battleAreaEl.style.gridTemplateRows = `repeat(${ROWS}, var(--cell))`;
+  const preservedFxLayer = fxLayer;
   battleAreaEl.innerHTML = '';
   for(let r=1;r<=ROWS;r++){
     for(let c=1;c<=COLS;c++){
@@ -2053,6 +3052,9 @@ function buildGrid(){
       cell.addEventListener('contextmenu', (e)=>{ e.preventDefault(); if(interactionLocked) return; clearSkillAiming(); renderAll(); });
       battleAreaEl.appendChild(cell);
     }
+  }
+  if(preservedFxLayer){
+    battleAreaEl.appendChild(preservedFxLayer);
   }
 }
 function refreshLargeOverlays(){
@@ -2205,6 +3207,8 @@ function summarizeNegatives(u){
   if(u.status.bleed>0) parts.push(`流血x${u.status.bleed}`);
   if(u.status.hazBleedTurns>0) parts.push(`Haz流血x${u.status.hazBleedTurns}`);
   if(u.status.recoverStacks>0) parts.push(`恢复x${u.status.recoverStacks}`);
+  if(u.status.jixueStacks>0) parts.push(`鸡血x${u.status.jixueStacks}`);
+  if(u.status.dependStacks>0) parts.push(`依赖x${u.status.dependStacks}`);
   if(u._spBroken) parts.push(`SP崩溃`);
   if(hazMarkedTargetId && u.id === hazMarkedTargetId) parts.push('猎杀标记');
   if(u._stanceType && u._stanceTurns>0){
@@ -2474,9 +3478,9 @@ function processUnitsTurnStart(side){
   if(side==='enemy'){
     if(roundsPassed % 2 === 0){
       const haz = units['haz'];
-      if(haz && haz.hp>0){ haz.sp = Math.min(haz.maxSp, haz.sp+10); haz._spBroken = (haz.sp<=0); showGainFloat(haz.r,haz.c,0,10); appendLog('队员们听令！Haz +10SP'); }
+      if(haz && haz.hp>0){ haz.sp = Math.min(haz.maxSp, haz.sp+10); haz._spBroken = (haz.sp<=0); showGainFloat(haz,0,10); appendLog('队员们听令！Haz +10SP'); }
       for(const id in units){
-        const v=units[id]; if(v.team==='seven' && v.hp>0 && v.id!=='haz'){ v.sp = Math.min(v.maxSp, v.sp+5); v._spBroken=(v.sp<=0); showGainFloat(v.r,v.c,0,5); }
+        const v=units[id]; if(v.team==='seven' && v.hp>0 && v.id!=='haz'){ v.sp = Math.min(v.maxSp, v.sp+5); v._spBroken=(v.sp<=0); showGainFloat(v,0,5); }
       }
       appendLog('队员们听令！其他队员 +5SP');
     }
@@ -2514,7 +3518,7 @@ function processUnitsTurnStart(side){
         const beforeSP = u.sp;
         u.sp = Math.min(u.maxSp, u.sp + u._stanceSpPerTurn);
         u._spBroken = (u.sp<=0);
-        showGainFloat(u.r,u.c,0,u.sp-beforeSP);
+        showGainFloat(u,0,u.sp-beforeSP);
         appendLog(`${u.name} 的${u._stanceType==='defense'?'防御':'反伤'}姿态：+${u._stanceSpPerTurn} SP`);
       }
       u._stanceTurns = Math.max(0, u._stanceTurns - 1);
@@ -2526,11 +3530,11 @@ function processUnitsTurnStart(side){
     if(u.spPendingRestore!=null){
       const val = Math.min(u.maxSp, u.spPendingRestore);
       u.sp = val; u._spBroken = (u.sp<=0); u.spPendingRestore = null;
-      appendLog(`${u.name} 的 SP 自动恢复至 ${val}`); showGainFloat(u.r,u.c,0,val);
+      appendLog(`${u.name} 的 SP 自动恢复至 ${val}`); showGainFloat(u,0,val);
       if(u.id==='haz'){
         const heal = Math.max(1, Math.floor(u.maxHp*0.05));
         u.hp = Math.min(u.maxHp, u.hp + heal);
-        appendLog(`Haz 因SP恢复同时回复 ${heal} HP`); showGainFloat(u.r,u.c,heal,0);
+        appendLog(`Haz 因SP恢复同时回复 ${heal} HP`); showGainFloat(u,heal,0);
       }
     }
 
@@ -2539,7 +3543,7 @@ function processUnitsTurnStart(side){
       const before = u.hp;
       u.hp = Math.min(u.maxHp, u.hp + 5);
       u.status.recoverStacks = Math.max(0, u.status.recoverStacks - 1);
-      showGainFloat(u.r,u.c,u.hp-before,0);
+      showGainFloat(u,u.hp-before,0);
       appendLog(`${u.name} 的“恢复”触发：+5HP（剩余 ${u.status.recoverStacks}）`);
     }
 
@@ -2558,7 +3562,7 @@ function processUnitsTurnStart(side){
     if(u.id==='tusk' && u._fortressTurns>0){
       u.sp = Math.min(u.maxSp, u.sp+10);
       u._spBroken = (u.sp<=0);
-      showGainFloat(u.r,u.c,0,10);
+      showGainFloat(u,0,10);
       u._fortressTurns--;
     }
   }
@@ -2573,7 +3577,7 @@ function processUnitsTurnEnd(side){
       if((u.actionsThisTurn||0)===0){
         u.sp = Math.min(u.maxSp, u.sp + 10);
         u._spBroken = (u.sp<=0);
-        appendLog('Adora 冷静分析：+10SP'); showGainFloat(u.r,u.c,0,10);
+        appendLog('Adora 冷静分析：+10SP'); showGainFloat(u,0,10);
       }
     }
     if(u.id==='karma' && u.consecAttacks>0){ appendLog('Karma 连击在回合结束时重置'); u.consecAttacks=0; }
@@ -2599,7 +3603,7 @@ function applyEndOfRoundPassives(){
         v.sp = Math.min(v.maxSp, v.sp + 5);
         v._spBroken = (v.sp<=0);
         appendLog(`Adora 邻近治疗：为 ${v.name} 恢复 ${heal} HP 和 5 SP`);
-        showGainFloat(v.r,v.c,heal,5);
+        showGainFloat(v,heal,5);
       }
     }
   }
@@ -2614,6 +3618,12 @@ function finishEnemyTurn(){
   setTimeout(()=>{
     currentSide='player';
     playerSteps=computeBaseSteps();
+    if(playerBonusStepsNextTurn>0){
+      const bonus = playerBonusStepsNextTurn;
+      playerSteps += bonus;
+      appendLog(`先苦后甜：玩家额外 +${bonus} 步`);
+      playerBonusStepsNextTurn = 0;
+    }
     appendLog('敌方回合结束，玩家回合开始');
     applyLevelSuppression();
     applyParalysisAtTurnStart('player');

--- a/styles_Version12.css
+++ b/styles_Version12.css
@@ -265,6 +265,7 @@ body {
 .skillCard.green { border-left-color: #52c41a; }
 .skillCard.red { border-left-color: #ff7875; }
 .skillCard.blue { border-left: 6px solid #1890ff !important; }
+.skillCard.orange { border-left-color: #fa8c16; }
 .skillCard:hover { transform: translateY(-1px); background: #141c2b; }
 .skillCard.disabled { opacity: .6; filter: grayscale(0.1); cursor: not-allowed; }
 


### PR DESCRIPTION
## Summary
- inject a skill FX library that gives every skill a dedicated animation, including a mecha claw variant for Dario
- wire the roster’s skill executors into the FX map so their shots, buffs, and retaliations all trigger the right visuals
- implement Neyla’s “执行……” double-shot with execution logic, self-cost, and beam FX coverage

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69045bf1af148332ac73a84bcd2d28be